### PR TITLE
Add prompt config back into job templates

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -197,6 +197,12 @@ properties:
   # Email
   login.notifications.url:
     description: "The url for the notifications service (configure to use Notifications Service instead of SMTP server)"
+  login.prompt.username.text:
+    description: "The text used to prompt for a username during login"
+    default: Email
+  login.prompt.password.text:
+    description: "The text used to prompt for a password during login"
+    default: Password
   login.smtp:
     description: "SMTP server configuration, for password reset emails etc."
   login.smtp.host:

--- a/jobs/uaa/templates/login.yml.erb
+++ b/jobs/uaa/templates/login.yml.erb
@@ -79,6 +79,11 @@ login:
   <% if !properties.login.invitations_enabled.nil? %>
   invitationsEnabled: <%= properties.login.invitations_enabled %>
   <% end %>
+  prompt:
+    username:
+      text: <%= properties.login.prompt.username.text %>
+    password:
+      text: <%= properties.login.prompt.password.text %>
   <% if_p('login.saml.serviceProviderCertificate') do |serviceProviderCert| %>
   serviceProviderCertificate: |
     <%= serviceProviderCert.gsub("\n", "\n    ") %>


### PR DESCRIPTION
I noticed this change https://github.com/cloudfoundry/cf-release/pull/771 didn't appear to make it into uaa-release.  I'm hoping that was an accident and not on purpose. :) Here is a PR to add it back in case it was an accident.