### PR TITLE
reintroduce missing login.url

### DIFF
--- a/jobs/uaa/templates/login.yml.erb
+++ b/jobs/uaa/templates/login.yml.erb
@@ -14,6 +14,7 @@ name: login
     uaa_base = "#{protocol}://uaa.#{p('domain')}"
   end
 
+  login_url = p('uaa.url') ? p('uaa.url') : "#{protocol}://login.#{properties.domain}"
   login_entityBaseUrl = (properties.login && properties.login.saml.entity_base_url) ? "#{protocol}://#{properties.login.saml.entity_base_url}" : "#{protocol}://login.#{properties.domain}"
   login_entityId = (properties.login && properties.login.saml.entityid) ? properties.login.saml.entityid : properties.login.entity_id ? properties.login.entity_id : "login.#{properties.domain}"
   login_authorizeUrl = (properties.uaa.url) ? "#{properties.uaa.url}/oauth/authorize" : "#{protocol}://login.#{properties.domain}/oauth/authorize"
@@ -74,6 +75,7 @@ logout:
 
 login:
   brand: <%= properties.login.brand %>
+  url: <%= login_url %>
   entityBaseURL: <%= login_entityBaseUrl %>
   entityID: <%= login_entityId %>
   <% if !properties.login.invitations_enabled.nil? %>


### PR DESCRIPTION
It seems that [this commit](https://github.com/cloudfoundry/uaa-release/commit/3f25fa366e8376c3650595a3dfaf47a1418da5a2) accidentally removed the `login.url` property from `login.yml.erb`.

Because `login.url` is not defined in UAA's `login.yml`, the [UAA Spring Config](https://github.com/cloudfoundry/uaa/blob/3.0.1/uaa/src/main/webapp/WEB-INF/spring-servlet.xml#L367) falls back to `http://localhost:8080/uaa`, which now appears in the OTP prompt `cf login --sso`:
````
One Time Code ( Get one at http://localhost:8080/uaa/passcode )>
````

This is problematic for SAML users that are now not able to obtain a passcode and log in.
Maybe this (wrong) URL is used in other places.

Since this version of the UAA bosh release is used in CF releases 227-230, this makes it hard to upgrade to this release if you have SAML users. It would be nice if a new CF release could quickly be created with the new UAA release.