### PR TITLE
add login.smtp.from_address to uaa job spec

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -236,6 +236,8 @@ properties:
     description: "SMTP server username"
   login.smtp.password:
     description: "SMTP server password"
+  login.smtp.from_address:
+    description: "SMTP from address"
 
   # Clients
   uaa.clients:


### PR DESCRIPTION
This is a simple update to the job spec, to support PR https://github.com/cloudfoundry/uaa/pull/355 that adds this functionality to UAA.  