### PR TITLE
Reduce uaa.logging_level default from DEBUG to INFO

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -89,7 +89,7 @@ properties:
     description: "Deprecated. Use uaa.url for setting the location of UAA"
   uaa.logging_level:
     description: Set UAA logging level.  (e.g. TRACE, DEBUG, INFO)
-    default: DEBUG
+    default: INFO
   uaa.logging_use_rfc3339:
     description: "Sets the time format for log messages to be yyyy-MM-dd'T'HH:mm:ss.SSSXXX instead of yyyy-MM-dd HH:mm:ss.SSS"
     default: false


### PR DESCRIPTION
UAA should ship with a default value that is safe and unsurprising for
production deployments, where you want to:

- be able to see errors and warnings without scrolling through lots of debug
  information that may not be relevant
- reduce the throughput and volume of logs that are going into centralised
  stores like Logsearch
- be confident that sensitive information like credentials aren't being
  captured in logs under normal circumstances