### PR TITLE
32-fix-ruby-string: reinstate double-quoting.

### DIFF
--- a/jobs/uaa/templates/uaa.yml.erb
+++ b/jobs/uaa/templates/uaa.yml.erb
@@ -270,7 +270,7 @@
   #internal hostnames for subdomain mapping
   internal_hostnames = []
   if_p('domain') do |domain|
-    internal_hostnames.push('login.#{domain}')
+    internal_hostnames.push("login.#{domain}")
   end
   p_arr('uaa.zones.internal.hostnames').each do |hostname|
     internal_hostnames.push(hostname)


### PR DESCRIPTION
Ref issue https://github.com/cloudfoundry/uaa-release/issues/32 -- this code used to use double-quotes, but they were converted to single-quotes at some point.
