### PR TITLE
Make uaa tomcat bind address configurable

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -38,6 +38,8 @@ properties:
   uaa.port:
     description: "Port that uaa will accept connections on"
     default: 8080
+  uaa.host:
+    description: "Host that uaa will accept connections on"
   uaa.url:
     description: "The base url of the UAA"
   uaa.zones.internal.hostnames:
@@ -96,6 +98,8 @@ properties:
   uaa.ssl.port:
     description: If this property Tomcat will listen to this port and expect https traffic. If set to -1, Tomcat will not listen for https traffic.
     default: 8443
+  uaa.ssl.host:
+    description: Host that uaa will accept https connections on. Will only be used if uaa.ssl.port is set.
   uaa.ssl.protocol_header:
     description: The header to look for to determine if ssl termination was performed by a front end load balancer.
     default: x-forwarded-proto

--- a/jobs/uaa/templates/tomcat.server.xml.erb
+++ b/jobs/uaa/templates/tomcat.server.xml.erb
@@ -31,6 +31,9 @@
                connectionTimeout="20000"
                port="<%= p('uaa.port') %>"
                bindOnInit="false"
+               <% if_p("uaa.host") do |host| %>
+               address="<%= host %>"
+               <% end %>
     />
     <% end %>
 
@@ -47,6 +50,9 @@
                keyAlias="uaa_ssl_cert"
                keystorePass="k0*l*s3cur1tyr0ck$"
                bindOnInit="false"
+               <% if_p("uaa.ssl.host") do |ssl_host| %>
+               address="<%= ssl_host %>"
+               <% end %>
     />
     <% end %>
 


### PR DESCRIPTION
Allow UAA tomcat server to run on specified network interfaces. (i.e. localhost)

@mdellilo @aemengo