### PR TITLE
Optionally consume a router link for proxy server addresses

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -24,6 +24,10 @@ templates:
   messages.properties.erb: config/messages.properties
   uaa.crt.erb: config/uaa.crt
 
+consumes:
+- name: router
+  type: http-router
+  optional: true
 
 packages:
   - uaa_utils

--- a/jobs/uaa/templates/tomcat.server.xml.erb
+++ b/jobs/uaa/templates/tomcat.server.xml.erb
@@ -18,6 +18,11 @@
         regExIp = ip.gsub(".","\\.").gsub(":","\\:")
         internalProxies = regExIp  + "|" + internalProxies
       end
+    end.else_if_link('router') do |router|
+      router.instances.each do |instance|
+        regExAddress = instance.address.gsub(".","\\.").gsub(":","\\:")
+        internalProxies = regExAddress  + "|" + internalProxies
+      end
     end
     # If we don't have any proxies by now. Use the default list so we don't go blank
     if internalProxies.to_s.strip.length == 0


### PR DESCRIPTION
This simplifies deployment manifests by allowing operators to rely on links to provide this information (e.g. from the gorouter) rather than needing to configure properties.