### PR TITLE
uaa can find database address from a link

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -28,6 +28,9 @@ consumes:
 - name: router
   type: http-router
   optional: true
+- name: database
+  type: database
+  optional: true
 
 packages:
   - uaa_utils

--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -24,6 +24,10 @@ templates:
   messages.properties.erb: config/messages.properties
   uaa.crt.erb: config/uaa.crt
 
+consumes:
+- name: router
+  type: http-router
+  optional: true
 
 packages:
   - uaa_utils

--- a/jobs/uaa/templates/tomcat.server.xml.erb
+++ b/jobs/uaa/templates/tomcat.server.xml.erb
@@ -18,6 +18,11 @@
         regExIp = ip.gsub(".","\\.").gsub(":","\\:")
         internalProxies = regExIp  + "|" + internalProxies
       end
+    end.else_if_link('router') do |router|
+      router.instances.each do |instance|
+        regExAddress = instance.address.gsub(".","\\.").gsub(":","\\:")
+        internalProxies = regExAddress  + "|" + internalProxies
+      end
     end
     # If we don't have any proxies by now. Use the default list so we don't go blank
     if internalProxies.to_s.strip.length == 0

--- a/jobs/uaa/templates/uaa.yml.erb
+++ b/jobs/uaa/templates/uaa.yml.erb
@@ -59,6 +59,13 @@
   uaa_db_scheme = p('uaadb.db_scheme')
   issuer_uri = p('uaa.issuer', p('uaa.url'))
 
+  uaa_db_address = nil
+  if_p('uaadb.address') do |address|
+    uaa_db_address = address
+  end.else do
+    uaa_db_address = link('database').instances[0].address
+  end
+
   spring_profiles = p('uaadb.db_scheme')
   if p_opt('uaa.ldap.enabled') then
     spring_profiles = spring_profiles + ',ldap'
@@ -77,7 +84,7 @@
       'config' => '/var/vcap/jobs/uaa/config/log4j.properties'
     },
     'database' => {
-      'url' =>  "jdbc:#{p('uaadb.db_scheme')}://#{p('uaadb.address')}:#{p('uaadb.port')}/#{uaa_db['name']}",
+      'url' =>  "jdbc:#{p('uaadb.db_scheme')}://#{uaa_db_address}:#{p('uaadb.port')}/#{uaa_db['name']}",
       'username' => uaa_role['name'],
       'password' => uaa_role['password'],
       'maxactive' => p('uaa.database.max_connections'),
@@ -129,7 +136,7 @@
   params['delete'] = p('uaa.delete') if p_opt('uaa.delete')
 
   if uaa_db_scheme == 'sqlserver' then
-    params['database']['url'] = "jdbc:#{p('uaadb.db_scheme')}://#{p('uaadb.address')}:#{p('uaadb.port')};databaseName=#{uaa_db['name']}"
+    params['database']['url'] = "jdbc:#{p('uaadb.db_scheme')}://#{uaa_db_address}:#{p('uaadb.port')};databaseName=#{uaa_db['name']}"
   end
 
   # should the DB not use lower() function in SCIM queries (if true)

--- a/jobs/uaa_postgres/spec
+++ b/jobs/uaa_postgres/spec
@@ -13,12 +13,14 @@ packages:
   - uaa_utils
   - uaa_postgres-9.4.6
 
+provides:
+  - name: postgres
+    type: database
+
 properties:
   postgres.port:
     description: "The database port"
     default: 5524
-  postgres.address:
-    description: "The database address"
   postgres.databases:
     description: "A list of databases and associated properties to create"
   postgres.roles:


### PR DESCRIPTION
By (optionally) consuming a database link, deployment manifests
do not need to specify explicit database addresses in their
manifest, which allows the manifest to be simpler and more
automatable.

This currently only looks for address because that is the
only property consistent in database links. When database links
begin providing more-comprehensive properties, the consumption
can be updated.

This builds on #55 to reduce merge conflicts