### PR TITLE
Check for empty redirect-uris

### DIFF
--- a/jobs/uaa/templates/uaa.yml.erb
+++ b/jobs/uaa/templates/uaa.yml.erb
@@ -255,7 +255,7 @@
         message = message + "\nMissing property: uaa.clients.#{id}.authorized-grant-types"
       else
         message = message + "\nMissing property: uaa.clients.#{id}.secret" if client_data['secret'].nil? && client_data['authorized-grant-types'] != 'implicit'
-        message = message + "\nMissing property: uaa.clients.#{id}.redirect-uri" if (client_data['redirect-uri'].nil?) && (client_data['authorized-grant-types'] =~ /implicit|authorization_code/)
+        message = message + "\nMissing property: uaa.clients.#{id}.redirect-uri" if (client_data['redirect-uri'].nil? || client_data['redirect-uri'].empty?) && (client_data['authorized-grant-types'] =~ /implicit|authorization_code/)
         message = message + "\nMissing property: uaa.clients.#{id}.authorities" if (client_data['authorities'].nil?) && (client_data['authorized-grant-types'] =~ /client_credentials/)
         message = message + "\nMissing property: uaa.clients.#{id}.scope" if (client_data['scope'].nil?) && (client_data['authorized-grant-types'] != 'client_credentials')
       end


### PR DESCRIPTION
The check in the job template for redirect-uri [does not not currently match the logic in the bootstrap code](https://github.com/cloudfoundry/uaa/blob/fe946fdc871027fcea9278e97c09cbf270831cf4/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminBootstrap.java#L242)  so a manifest with ` redirect-uri: ""` will attempt to deploy but UAA will fail to start.
