### PR TITLE
Fixing bug in specs with logout properties

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -220,16 +220,6 @@ properties:
             write: Cancel the approvals like this one that you have granted to this and other applications
       scope.tokens.read: View details of your approvals you have granted to this and other applications
       scope.tokens.write: Cancel the approvals like this one that you have granted to this and other applications
-  login.logout.redirect.url:
-    description: "The Location of the redirect header following a logout of the the UAA (/logout.do)."
-    default: /login
-  login.logout.redirect.parameter.disable:
-    description: "When set to false, this allows an operator to leverage an open redirect on the UAA (/logout.do?redirect=google.com). No open redirect enabled"
-    default: true
-  login.logout.redirect.parameter.whitelist:
-    description: "A list of URLs. When this list is non null, including empty, and disable=false,
-    logout redirects are allowed, but limited to the whitelist URLs. If a redirect parameter value is not white
-    listed, redirect will be to the default URL."
   login.prompt.username.text:
     description: "The text used to prompt for a username during login"
     default: Email
@@ -263,6 +253,18 @@ properties:
   login.smtp.starttls:
     description: "If true, send STARTTLS command before login to server. https://javamail.java.net/nonav/docs/api/com/sun/mail/smtp/package-summary.html"
     default: false
+
+# Logout configurations
+  logout.redirect.url:
+    description: "The Location of the redirect header following a logout of the the UAA (/logout.do)."
+    default: /login
+  logout.redirect.parameter.disable:
+    description: "When set to false, this allows an operator to leverage an open redirect on the UAA (/logout.do?redirect=google.com). No open redirect enabled"
+    default: true
+  logout.redirect.parameter.whitelist:
+    description: "A list of URLs. When this list is non null, including empty, and disable=false,
+    logout redirects are allowed, but limited to the whitelist URLs. If a redirect parameter value is not white
+    listed, redirect will be to the default URL."
 
   # Delete actions
   uaa.delete:

--- a/jobs/uaa/templates/uaa.yml.erb
+++ b/jobs/uaa/templates/uaa.yml.erb
@@ -476,9 +476,9 @@
     'assetBaseUrl' => p('login.asset_base_url'),
     'logout' => {
       'redirect' => {
-        'url' => p('login.logout.redirect.url'),
+        'url' => p('logout.redirect.url'),
         'parameter' => {
-          'disable' => p('login.logout.redirect.parameter.disable')
+          'disable' => p('logout.redirect.parameter.disable')
         }
       }
     },
@@ -519,7 +519,7 @@
   #deprecated property still works
   add_value(params, p('login.home_redirect'), 'links', 'homeRedirect') if p_opt('login.home_redirect')
 
-  add_value(params, p('login.logout.redirect.parameter.whitelist'), 'logout', 'redirect', 'parameter', 'whitelist') if p_opt('login.logout.redirect.parameter.whitelist')
+  add_value(params, p('logout.redirect.parameter.whitelist'), 'logout', 'redirect', 'parameter', 'whitelist') if p_opt('logout.redirect.parameter.whitelist')
 
   if_p('login.smtp') do |login_smtp|
     login_smtp.each do |key,val|

--- a/spec/input/all-properties-set.yml
+++ b/spec/input/all-properties-set.yml
@@ -32,15 +32,6 @@ properties:
       passwd: /reset_password
       signup: http://signup.somewhere.else
       homeRedirect: http://custom.home.redirect
-    logout:
-      redirect:
-        parameter:
-          disable: true
-        url: /
-        whitelist:
-        - http://url1
-        - http://url2
-        - http://url3
     messages:
       scope:
         tokens:
@@ -336,6 +327,16 @@ properties:
       port: 25
       starttls: true
       user: smtp_user
+  logout:
+    redirect:
+      parameter:
+        disable: true
+      url: /
+      whitelist:
+      - http://url1
+      - http://url2
+      - http://url3
+
   uaa:
     admin:
       client_secret: adminsecret

--- a/spec/input/bosh-lite.yml
+++ b/spec/input/bosh-lite.yml
@@ -1004,7 +1004,6 @@ properties:
     links:
       passwd: https://login.bosh-lite.com/forgot_password
       signup: https://login.bosh-lite.com/create_account
-    logout:
     messages:
     notifications:
       url:
@@ -1094,6 +1093,7 @@ properties:
       user:
       from_address:
     url:
+  logout:
   metron_agent:
     buffer_size:
     deployment: cf-warden


### PR DESCRIPTION
In current specs, "logout" property is placed as a child of "login". Example:
**login.logout.redirect.url**
But this is wrong. Logout is a sibling of "login" and should be on the same level.
This issue in the specs made a lot of problems and bugs in our project, as UAA was not able to read **login.logout.redirect** properties.