### PR TITLE
Make healthcheck drain time configurable

### DIFF
--- a/jobs/uaa/monit
+++ b/jobs/uaa/monit
@@ -1,7 +1,7 @@
 check process uaa
   with pidfile /var/vcap/sys/run/uaa/uaa.pid
   start program "/var/vcap/jobs/uaa/bin/uaa_ctl start"
-  stop program "/var/vcap/jobs/uaa/bin/uaa_ctl stop"
+  stop program "/var/vcap/jobs/uaa/bin/uaa_ctl stop" with timeout 60 seconds
   group vcap
   if failed port 8989 protocol http
     request "/healthz"

--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -957,3 +957,11 @@ properties:
         path: <(String) path for cookie, default is />
         domain: <(String) domain for cookie, default is incoming request domain>
     default: ~
+  uaa.healthcheck.drain_time:
+    description:
+      The amount of time the health check will fail before the uaa process is stopped.
+      This allows load balancers UAA may be behind a chance to unregister the instance.
+      Note, this increases the execution time of the Monit stop operation, which cannot
+      exceed a configured timeout. See the Monit configuration file in this release for
+      the current timeout.
+    default: 20

--- a/jobs/uaa/templates/uaa_ctl.erb
+++ b/jobs/uaa/templates/uaa_ctl.erb
@@ -186,7 +186,7 @@ case $1 in
     # This tells the health_check to return false
     # and the route will be deregistered
     rm -f $STATUS
-    sleep 5
+    sleep <%= p('uaa.healthcheck.drain_time') %>
     echo "[uaa-stop] Health check STATUS file removed"
     if pid_guard $PIDFILE "UAA"
     then


### PR DESCRIPTION
## What

Make healthcheck drain time configurable. This is the amount of time the healthcheck fails for before the UAA process is killed.
    
## Why

Increasing this time to 20 seconds by default allows load balancers that UAA may be behind to unregister the instance. We make it configurable because load balancer's configurations may vary.

Without this extra drain time the UAA API will suffer downtime of a few seconds when being restarted or redeployed, which is unacceptable in a high availability deployment.

## How to review

* assert when the manifest lacks this property the template renders a value of 20
* assert when the manifest includes this property the template renders that value.
* assert the execution time of `monit stop uaa` does not exceed the configured timeout.
