### PR TITLE
fix saml signRequest and signMetadata

### DIFF
--- a/jobs/uaa/templates/uaa.yml.erb
+++ b/jobs/uaa/templates/uaa.yml.erb
@@ -654,8 +654,8 @@
     end
   end
 
-  add_value(params, p('login.saml.signMetaData'), 'login', 'saml', 'signMetaData') if p_opt('login.saml.signMetaData')
-  add_value(params, p('login.saml.signRequest'), 'login', 'saml', 'signRequest') if p_opt('login.saml.signRequest')
+  add_value(params, p('login.saml.signMetaData'), 'login', 'saml', 'signMetaData') if not p_opt('login.saml.signMetaData').nil?
+  add_value(params, p('login.saml.signRequest'), 'login', 'saml', 'signRequest') if not p_opt('login.saml.signRequest').nil?
   add_value(params, p('login.saml.wantAssertionSigned'), 'login', 'saml', 'wantAssertionSigned')
   add_value(params, p('login.saml.disableInResponseToCheck'), 'login', 'saml', 'disableInResponseToCheck')
   if_p('login.saml.signatureAlgorithm') { |alg| add_value(params, alg, 'login', 'saml', 'signatureAlgorithm') }


### PR DESCRIPTION
By default these two values are true, so we should set them when false is provided otherwise we would never be able to set them false.