### PR TITLE
Clarify unique refresh token behavior

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -571,11 +571,11 @@ properties:
     description: "Disallows refresh-token grant for any client for which the user has not approved the `uaa.offline_token` scope"
     default: false
   uaa.jwt.refresh.unique:
-      description: "If true, uaa will only issue one refresh token per client_id/user_id combination"
-      default: false
+    description: "Revokes existing refresh tokens for client-user combination when creating a new refresh token. Note: only applies if `uaa.jwt.revocable` is true."
+    default: false
   uaa.jwt.refresh.format:
-      description: "The format for the refresh token. Allowed values are `jwt`, `opaque`"
-      default: jwt
+    description: "The format for the refresh token. Allowed values are `jwt`, `opaque`"
+    default: jwt
 
   # Global security policies (for all zones)
   uaa.authentication.policy.global.lockoutAfterFailures:


### PR DESCRIPTION
I found the existing docs to be a little vague and had to read the source and experiment with the `unique` and `revocable` flags to figure out exactly how this works. I think this will be a little more clear.