### PR TITLE
Feature: implement a YAML 'scopes' list for UAA clients

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -555,7 +555,9 @@ properties:
         secret: app-secret
         authorized-grant-types: authorization_code,client_credentials,refresh_token
         authorities: test_resource.test_action
-        scope: test_resource.test_action,test_resource.other_action
+        scopes: # overrides anything present in 'scope' property
+          - test_resource.test_action
+          - test_resource.other_action
         redirect-uri: http://login.example.com
         autoapprove:
         - test_resource.test_action

--- a/jobs/uaa/templates/config/uaa.yml.erb
+++ b/jobs/uaa/templates/config/uaa.yml.erb
@@ -1,4 +1,6 @@
 <%
+  require 'uri'
+
   message = ''
 
   hex_code_regex = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/

--- a/jobs/uaa/templates/config/uaa.yml.erb
+++ b/jobs/uaa/templates/config/uaa.yml.erb
@@ -74,25 +74,25 @@
     if (is_missing(currentMap, 'login', 'serviceProviderKey') &&
         is_missing(currentMap, 'login', 'serviceProviderKeyPassword') &&
         is_missing(currentMap, 'login', 'serviceProviderCertificate'))
-      errorinfo = errorinfo + (is_missing(currentMap, 'login', 'saml', 'keys')?'\nMissing property: login.saml.keys' : '')
+      errorinfo = errorinfo + (is_missing(currentMap, 'login', 'saml', 'keys') ? '\nMissing property: login.saml.keys' : '')
       if errorinfo !~ /login.saml.keys/
         #validate that the keys are intact
         currentMap['login']['saml']['keys'].each do |keyName,keyContents|
-          errorinfo = errorinfo + (is_missing(currentMap, 'login', 'saml', 'keys', keyName, 'certificate')?'\nMissing property: login.saml.keys.' + keyName + '.certificate' : '')
-          errorinfo = errorinfo + (is_missing(currentMap, 'login', 'saml', 'keys', keyName, 'passphrase')?'\nMissing property: login.saml.keys.' + keyName + '.passphrase' : '')
-          errorinfo = errorinfo + (is_missing(currentMap, 'login', 'saml', 'keys', keyName, 'key')?'\nMissing property: login.saml.keys.' + keyName + '.key' : '')
+          errorinfo = errorinfo + (is_missing(currentMap, 'login', 'saml', 'keys', keyName, 'certificate') ? '\nMissing property: login.saml.keys.' + keyName + '.certificate' : '')
+          errorinfo = errorinfo + (is_missing(currentMap, 'login', 'saml', 'keys', keyName, 'passphrase') ? '\nMissing property: login.saml.keys.' + keyName + '.passphrase' : '')
+          errorinfo = errorinfo + (is_missing(currentMap, 'login', 'saml', 'keys', keyName, 'key') ? '\nMissing property: login.saml.keys.' + keyName + '.key' : '')
         end
       end
-      errorinfo = errorinfo + (is_missing(currentMap, 'login', 'saml', 'activeKeyId')?'\nMissing property: login.saml.activeKeyId' : '')
+      errorinfo = errorinfo + (is_missing(currentMap, 'login', 'saml', 'activeKeyId') ? '\nMissing property: login.saml.activeKeyId' : '')
       if errorinfo !~ /login.saml.activeKeyId/
         #validate that activeKeyId points to a valid key
         keyId = currentMap['login']['saml']['activeKeyId']
-        errorinfo = errorinfo + (is_missing(currentMap, 'login', 'saml', 'keys', keyId)?'\Invalid login.saml.activeKeyId: login.saml.keys.' + keyId + ' does not exist' : '')
+        errorinfo = errorinfo + (is_missing(currentMap, 'login', 'saml', 'keys', keyId) ? '\Invalid login.saml.activeKeyId: login.saml.keys.' + keyId + ' does not exist' : '')
       end
     else
-      errorinfo = errorinfo + (is_missing(currentMap, 'login', 'serviceProviderKey')?'\nMissing property: login.saml.serviceProviderKey' : '')
-      errorinfo = errorinfo + (is_missing(currentMap, 'login', 'serviceProviderKeyPassword')?'\nMissing property: login.saml.serviceProviderKeyPassword' : '')
-      errorinfo = errorinfo + (is_missing(currentMap, 'login', 'serviceProviderCertificate')?'\nMissing property: login.saml.serviceProviderCertificate' : '')
+      errorinfo = errorinfo + (is_missing(currentMap, 'login', 'serviceProviderKey') ? '\nMissing property: login.saml.serviceProviderKey' : '')
+      errorinfo = errorinfo + (is_missing(currentMap, 'login', 'serviceProviderKeyPassword') ? '\nMissing property: login.saml.serviceProviderKeyPassword' : '')
+      errorinfo = errorinfo + (is_missing(currentMap, 'login', 'serviceProviderCertificate') ? '\nMissing property: login.saml.serviceProviderCertificate' : '')
     end
     return errorinfo
   end

--- a/jobs/uaa/templates/config/uaa.yml.erb
+++ b/jobs/uaa/templates/config/uaa.yml.erb
@@ -382,7 +382,7 @@
           message = message + "\nClient redirect-uri is invalid: uaa.clients.#{id}.redirect-uri"
         end
         message = message + "\nMissing property: uaa.clients.#{id}.authorities" if (client_data['authorities'].nil?) && (client_data['authorized-grant-types'] =~ /client_credentials/)
-        message = message + "\nMissing property: uaa.clients.#{id}.scope" if (client_data['scope'].nil?) && (client_data['authorized-grant-types'] != 'client_credentials')
+        message = message + "\nMissing property: uaa.clients.#{id}.scope or uaa.clients.#{id}.scopes" if (client_data['scope'].nil?) && (client_data['authorized-grant-types'] != 'client_credentials')
       end
 
       ['refresh-token-validity', 'access-token-validity'].each do |numberProperty|

--- a/jobs/uaa/templates/config/uaa.yml.erb
+++ b/jobs/uaa/templates/config/uaa.yml.erb
@@ -364,6 +364,12 @@
       client.each do |key,value|
         client_data[key] = value
       end
+      if !client['scopes'].nil?
+        client_data.delete('scopes')
+        if client['scopes'].is_a? Array
+          client_data['scope'] = client['scopes'].join(',')
+        end
+      end
       add_value(oauth, client_data, 'clients', id)
       add_value(oauth, id, 'clients', id, 'id')
       if is_missing(client_data, 'authorized-grant-types')

--- a/spec/compare/all-properties-set-uaa.yml
+++ b/spec/compare/all-properties-set-uaa.yml
@@ -190,6 +190,20 @@ oauth:
       app-launch-url: http://myapppage.com
       show-on-homepage: true
       app-icon: iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAD1BMVEWZttQvMDEoKisqKywAAAApvvoVAAAAGElEQVQYlWNgYUQBLAxMDCiAeXgLoHsfAD03AHOyfqy1AAAAAElFTkSuQmCC
+    app-with-yaml-scopes:
+      id: app-with-yaml-scopes
+      override: true
+      secret: app-secret
+      authorized-grant-types: authorization_code,client_credentials,refresh_token
+      authorities: test_resource.test_action
+      scope: test_resource.test_action,test_resource.other_action
+      redirect-uri: http://login.example.com
+      autoapprove:
+      - test_resource.test_action
+      - test_resource.other_action
+      app-launch-url: http://myapppage.com
+      show-on-homepage: true
+      app-icon: iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAD1BMVEWZttQvMDEoKisqKywAAAApvvoVAAAAGElEQVQYlWNgYUQBLAxMDCiAeXgLoHsfAD03AHOyfqy1AAAAAElFTkSuQmCC
     admin:
       authorized-grant-types: client_credentials
       authorities: clients.read,clients.write,clients.secret,uaa.admin,scim.read,scim.write,password.write

--- a/spec/input/all-properties-set.yml
+++ b/spec/input/all-properties-set.yml
@@ -426,6 +426,21 @@ properties:
         scope: test_resource.test_action,test_resource.other_action
         secret: app-secret
         show-on-homepage: true
+      app-with-yaml-scopes:
+        app-icon: iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAD1BMVEWZttQvMDEoKisqKywAAAApvvoVAAAAGElEQVQYlWNgYUQBLAxMDCiAeXgLoHsfAD03AHOyfqy1AAAAAElFTkSuQmCC
+        app-launch-url: http://myapppage.com
+        authorities: test_resource.test_action
+        authorized-grant-types: authorization_code,client_credentials,refresh_token
+        autoapprove:
+        - test_resource.test_action
+        - test_resource.other_action
+        override: true
+        redirect-uri: http://login.example.com
+        scopes:
+          - test_resource.test_action
+          - test_resource.other_action
+        secret: app-secret
+        show-on-homepage: true
       cf:
         access-token-validity: 600
         authorities: uaa.none

--- a/spec/uaa-release.erb_spec.rb
+++ b/spec/uaa-release.erb_spec.rb
@@ -527,6 +527,25 @@ describe 'uaa-release erb generation' do
       end
     end
 
+    context "and either 'scope' string or 'scopes' list is required on a client" do
+      let(:erb_template) { '../jobs/uaa/templates/config/uaa.yml.erb' }
+      grant_types_requiring_secret = ['implicit',
+                                      'authorization_code',
+                                      'password',
+                                      'urn:ietf:params:oauth:grant-type:saml2-bearer',
+                                      'user_token',
+                                      'urn:ietf:params:oauth:grant-type:jwt-bearer']
+      grant_types_requiring_secret.each do |grant_type|
+        it "raises an error for type:#{grant_type}" do
+          generated_cf_manifest['properties']['uaa']['clients']['app-with-yaml-scopes']['authorized-grant-types'] = grant_type;
+          generated_cf_manifest['properties']['uaa']['clients']['app-with-yaml-scopes'].delete('scopes');
+          expect {
+            parsed_yaml
+          }.to raise_error(ArgumentError, /Missing property: uaa.clients.app-with-yaml-scopes.scope/)
+        end
+      end
+    end
+
 
   end
 

--- a/spec/uaa-release.erb_spec.rb
+++ b/spec/uaa-release.erb_spec.rb
@@ -522,7 +522,7 @@ describe 'uaa-release erb generation' do
           generated_cf_manifest['properties']['uaa']['clients']['app'].delete('scope');
           expect {
             parsed_yaml
-          }.to raise_error(ArgumentError, /Missing property: uaa.clients.app.scope/)
+          }.to raise_error(ArgumentError, /Missing property: uaa.clients.app.scope or uaa.clients.app.scopes/)
         end
       end
     end
@@ -541,7 +541,7 @@ describe 'uaa-release erb generation' do
           generated_cf_manifest['properties']['uaa']['clients']['app-with-yaml-scopes'].delete('scopes');
           expect {
             parsed_yaml
-          }.to raise_error(ArgumentError, /Missing property: uaa.clients.app-with-yaml-scopes.scope/)
+          }.to raise_error(ArgumentError, /Missing property: uaa.clients.app-with-yaml-scopes.scope or uaa.clients.app-with-yaml-scopes.scopes/)
         end
       end
     end


### PR DESCRIPTION
Hi there,

As it turns out in cloudfoundry/cf-deployment#495, we would need a YAML list for UAA clients scopes.

This PR implements such a YAML `scopes` list. When the `scopes` list is present, it overrides anything set in `scope`.

With this new feature, it will be easier to implement ops files that add specific scopes to existing UAA clients.

Best,