### PR TITLE
example operator file to enable MFA on default zone for google auth/authy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ releases/**/*.tgz
 bosh-lite/manifests/*
 bosh-lite/tmp/*
 pkg
+tmp

--- a/templates/ops-files/enable-mfa-google-auth-default-zone.yml
+++ b/templates/ops-files/enable-mfa-google-auth-default-zone.yml
@@ -1,0 +1,11 @@
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/login?/mfa
+  value:
+    providers:
+      2fa:
+        type: google-authenticator
+        config:
+          providerDescription: Add google authenticator/authy to the default zone
+          issuer: uaa
+    providerName: 2fa
+    enabled: true


### PR DESCRIPTION
Looks fantastic. And it "just works" after turning it on. Fabulous.

![screen shot 2018-06-20 at 9 57 48 am](https://user-images.githubusercontent.com/108/41630286-9453f480-7471-11e8-96fc-bf260554e9da.png)
