### PR TITLE
Ensure that unlock scripts wait enough time to populate routes

### DIFF
--- a/jobs/uaa/templates/bbr/post-backup-unlock.sh.erb
+++ b/jobs/uaa/templates/bbr/post-backup-unlock.sh.erb
@@ -1,5 +1,26 @@
 #!/bin/bash
 
+function give_route_registrar_enough_time() {
+  local max_attempts=180
+  local min_successes=10
+  local uaa_endpoint=<%= p('uaa.url').sub("://uaa.", "://login.") %>
+  local successes=0
+  echo -n "Waiting for $uaa_endpoint to become available"
+  for attempt in $(seq "${max_attempts}"); do
+    local http_code=$(curl -k -w "%{http_code}" -o /dev/null -s "${uaa_endpoint}")
+    if [[ "${http_code}" == "200" ]]; then
+      let successes="${successes}"+1
+    else
+      let successes=0
+    fi
+    if [[ "${successes}" -ge "${min_successes}" ]]; then
+      break
+    fi
+    echo -n "."
+    sleep 1
+  done
+  echo
+}
 
 <% if p('release_level_backup') %>
 function disable_limited_functionality() {
@@ -9,4 +30,5 @@ function disable_limited_functionality() {
   disable_limited_functionality
   #uaa checks the file system every 5 seconds
   sleep 6
+  give_route_registrar_enough_time
 <% end %>

--- a/jobs/uaa/templates/bbr/post-restore-unlock.sh.erb
+++ b/jobs/uaa/templates/bbr/post-restore-unlock.sh.erb
@@ -1,9 +1,30 @@
 #!/bin/bash
 
+function give_route_registrar_enough_time() {
+  local max_attempts=180
+  local min_successes=10
+  local uaa_endpoint=<%= p('uaa.url').sub("://uaa.", "://login.") %>
+  local successes=0
+  echo -n "Waiting for $uaa_endpoint to become available"
+  for attempt in $(seq "${max_attempts}"); do
+    local http_code=$(curl -k -w "%{http_code}" -o /dev/null -s "${uaa_endpoint}")
+    if [[ "${http_code}" == "200" ]]; then
+      let successes="${successes}"+1
+    else
+      let successes=0
+    fi
+    if [[ "${successes}" -ge "${min_successes}" ]]; then
+      break
+    fi
+    echo -n "."
+    sleep 1
+  done
+  echo
+}
+
 # start the UAA
 <% if p('release_level_backup') %>
   /var/vcap/bosh/bin/monit start uaa
   /var/vcap/jobs/uaa/bin/post-start
-  #give route registrar enough time
-  sleep 40
+  give_route_registrar_enough_time
 <% end %>


### PR DESCRIPTION
Make scripts require 10 robust success responses before declaring
server to be "healthy". Scripts will wait up to 3 minutes.

[#164409886] **[Feature Improvement]** improve PDRATs reliability by improving the way autoscaling, usage-service and notifications block on CAPI availability in their BBR scripts

Signed-off-by: Elena Sharma <esharma@pivotal.io>