### PR TITLE
Stop tomcat on initialization failure.

### DIFF
--- a/jobs/uaa/monit
+++ b/jobs/uaa/monit
@@ -3,7 +3,3 @@ check process uaa
   start program "/var/vcap/jobs/bpm/bin/bpm start uaa"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop uaa"
   group vcap
-  if failed port <%= p('uaa.localhost_http_port') %> protocol http
-    request "/healthz"
-    with timeout 60 seconds for 64 cycles
-  then restart

--- a/jobs/uaa/templates/bin/health_check.erb
+++ b/jobs/uaa/templates/bin/health_check.erb
@@ -6,8 +6,6 @@ HEALTH_RESPONSE=$(curl -ksS --max-time 5 --connect-timeout 2 https://127.0.0.1:<
 
 if [[ "${HEALTH_RESPONSE}" == "ok" ]]; then
   exit 0
-elif [[ "${HEALTH_RESPONSE}" == "FAILURE" ]]; then
-  exit 2
 else
   exit 1
 fi

--- a/jobs/uaa/templates/bin/post-start
+++ b/jobs/uaa/templates/bin/post-start
@@ -37,11 +37,6 @@ while [ "${WHEN_NOW}" -ot "${WHEN_FINISH}" ]; do
         log "Health check successful"
         delete_ts_files
         exit 0
-    elif  [ "$check" == "2" ]
-    then
-        log "FAILED: Server failed to start successfully. Check uaa.log to find out why the server failed to start."
-        delete_ts_files
-        exit 1
     fi
 
     sleep 1

--- a/jobs/uaa/templates/config/tomcat/tomcat.server.xml.erb
+++ b/jobs/uaa/templates/config/tomcat/tomcat.server.xml.erb
@@ -5,6 +5,7 @@
   <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
   <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
   <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+  <Listener className="org.cloudfoundry.identity.uaa.web.tomcat.UaaStartupFailureListener" />
 
   <Service name="Catalina">
     <%

--- a/packages/uaa/packaging
+++ b/packages/uaa/packaging
@@ -28,6 +28,7 @@ cd tomcat
 rm -rf webapps/*
 cp -a ${BOSH_COMPILE_TARGET}/uaa/cloudfoundry-identity-uaa.war webapps/ROOT.war
 cp -a ${BOSH_COMPILE_TARGET}/uaa/cloudfoundry-identity-statsd.war webapps/statsd.war
+cp -a ${BOSH_COMPILE_TARGET}/uaa/tomcat-listener.jar lib/tomcat-listener.jar
 cp -a ${BOSH_COMPILE_TARGET}/uaa/newrelic.jar bin/newrelic.jar
 
 chmod 0755 bin/

--- a/packages/uaa/pre_packaging
+++ b/packages/uaa/pre_packaging
@@ -26,8 +26,9 @@ export PATH=$JAVA_HOME/bin:$PATH
 #build cloud foundry UAA war
 cd ${BUILD_DIR}/uaa
 GIT_DIR=$(find $RELEASE_DIR -path "*/modules/src/uaa") ./gradlew :clean :assemble -Pversion=${UAA_VERSION}
-cp uaa/build/libs/cloudfoundry-identity-uaa-*.war ${BUILD_DIR}/uaa/cloudfoundry-identity-uaa.war
-cp statsd/build/libs/cloudfoundry-identity-statsd-*.war ${BUILD_DIR}/uaa/cloudfoundry-identity-statsd.war
+cp uaa/build/libs/cloudfoundry-identity-uaa-${UAA_VERSION}.war ${BUILD_DIR}/uaa/cloudfoundry-identity-uaa.war
+cp statsd/build/libs/cloudfoundry-identity-statsd-${UAA_VERSION}.war ${BUILD_DIR}/uaa/cloudfoundry-identity-statsd.war
+cp server/build/libs/tomcat-listener-${UAA_VERSION}.jar ${BUILD_DIR}/uaa/tomcat-listener.jar
 
 #clean build UAA data and build tools (java)
 ./gradlew clean
@@ -54,3 +55,4 @@ rm -f ${BUILD_DIR}/uaa/README.md
 rm -f ${BUILD_DIR}/uaa/settings.gradle
 rm -f ${BUILD_DIR}/uaa/shared_versions.gradle
 rm -rf ${BUILD_DIR}/uaa/uaa
+

--- a/spec/compare/all-properties-tomcat-server.xml
+++ b/spec/compare/all-properties-tomcat-server.xml
@@ -5,6 +5,7 @@
   <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener"/>
   <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener"/>
   <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener"/>
+  <Listener className="org.cloudfoundry.identity.uaa.web.tomcat.UaaStartupFailureListener" />
 
   <Service name="Catalina">
     <Connector class="org.apache.coyote.http11.Http11NioProtocol"

--- a/spec/compare/health-check
+++ b/spec/compare/health-check
@@ -6,8 +6,6 @@ HEALTH_RESPONSE=$(curl -ksS --max-time 5 --connect-timeout 2 https://127.0.0.1:9
 
 if [[ "${HEALTH_RESPONSE}" == "ok" ]]; then
   exit 0
-elif [[ "${HEALTH_RESPONSE}" == "FAILURE" ]]; then
-  exit 2
 else
   exit 1
 fi


### PR DESCRIPTION
## Why is this change needed?

When a BOSH director restarts, the UAA sometimes starts before the local postgres instance. This scenario confuses the UAA because it expects the database to be available. In a BOSH release, the UAA will eventually be restarted because monit is checking for successful responses from the `/healthz` endpoint which it will not get.

This is problematic for operators for two reasons:
1. The UAA process appears to be running. They need to remember to check the `/healthz` endpoint.
1. While the UAA will be restarted, it's only after ~8 minutes. That's a long time, which means the operator might have to get involved.

## How does this PR address the issue.

This PR simplifies this situation by removing the failure mode and providing some utilities for stopping the servlet container if the UAA fails to start up correctly. The UAA will keep trying to start until the database is available. 

This is an improvement for the operator because:
1. The UAA will recover faster than 8 minutes.
1. If the database never becomes available the UAA will never successfully start. This is a situation which should require the operators attention.