### PR TITLE
Add ability to set portHeader in tomcat's server.xml

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -224,6 +224,9 @@ properties:
   uaa.ssl.protocol_header:
     description: The header to look for to determine if ssl termination was performed by a front end load balancer.
     default: x-forwarded-proto
+  uaa.ssl.port_header:
+    description: The header to look for to determine the port where ssl termination was performed by a front end load balancer.
+    default: X-Forwarded-Port
   uaa.sslCertificate:
     description: "The server's ssl certificate. The default is a self-signed certificate and should always be replaced for production deployments"
     default: ''

--- a/jobs/uaa/templates/config/tomcat/tomcat.server.xml.erb
+++ b/jobs/uaa/templates/config/tomcat/tomcat.server.xml.erb
@@ -88,6 +88,7 @@
                remoteIpHeader="x-forwarded-for"
                protocolHeader="<%= p('uaa.ssl.protocol_header') %>"
                internalProxies="<%= internal_proxies %>"
+               portHeader="<%= p('uaa.ssl.port_header') %>"
         />
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="/var/vcap/sys/log/uaa"
                prefix="localhost_access" suffix=".log" rotatable="false" pattern="%h %l %u %t &quot;%m %U %H&quot; %s %b"/>

--- a/spec/compare/all-properties-tomcat-server.xml
+++ b/spec/compare/all-properties-tomcat-server.xml
@@ -44,6 +44,7 @@
                remoteIpHeader="x-forwarded-for"
                protocolHeader="x-forwarded-proto"
                internalProxies="127\.1\.0\.1|127\.1\.0\.2|127\.1\.0\.3|10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}"
+               portHeader="X-Forwarded-Port"
         />
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="/var/vcap/sys/log/uaa"
                prefix="localhost_access" suffix=".log" rotatable="false" pattern="%h %l %u %t &quot;%m %U %H&quot; %s %b"/>


### PR DESCRIPTION
If UAA receives a request from a proxy/load balancer where a port mapping is happening, any redirect from UAA will pick the default port number (443 if https), which is the wrong port where that proxy/load balancer is listening to and doing the ssl termination. This commit updates the tomcat 
server config file `server.xml` to get the port from `X-Forwarded-Port` if it is specified. This header should be set by the proxy/load balancer.