### PR TITLE
Add bosh-dns healthy script to match the route_registrar health_check

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -10,6 +10,7 @@ templates:
   bin/health_check.erb: bin/health_check
   bin/pre-start.erb: bin/pre-start
   bin/post-start: bin/post-start
+  bin/dns/healthy.erb: bin/dns/healthy
 
   config/uaa.yml.erb: config/uaa.yml
   config/bpm.yml.erb: config/bpm.yml

--- a/jobs/uaa/templates/bin/dns/healthy.erb
+++ b/jobs/uaa/templates/bin/dns/healthy.erb
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -u
+
+HEALTH_RESPONSE=$(curl -ksS --max-time 5 --connect-timeout 2 https://127.0.0.1:<%= p('uaa.ssl.port') %>/healthz)
+
+if [[ "${HEALTH_RESPONSE}" == "ok" ]]; then
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
This change will provide the UAA specific bosh dns healthcheck.