### PR TITLE
openjdk Trusty no longer supported, bump to bionic 11.0.6, not known to have as many CVEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Add the following properties to your manifest:
 
    Java Runtime Environments are graciously supplied by the Cloud Foundry Java Buildpack Team
 
-   JDK - https://java-buildpack.cloudfoundry.org/openjdk-jdk/trusty/x86_64/index.yml
-   JRE - https://java-buildpack.cloudfoundry.org/openjdk/trusty/x86_64/index.yml
+   JDK - https://java-buildpack.cloudfoundry.org/openjdk-jdk/bionic/x86_64/index.yml
+   JRE - https://java-buildpack.cloudfoundry.org/openjdk/bionic/x86_64/index.yml
 
 ## Acknowledgements
 

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-openjdk/openjdk-11.0.4_11-x86_64-trusty.tar.gz:
-  size: 195187242
+openjdk/openjdk-11.0.6_10-x86_64-bionic.tar.gz:
+  size: 196497777
   object_id: 818deb54-a1fd-4e95-76c7-e32449d8b739
-  sha: 3e51fc95c556aad87a1b136ca23cb2dea617482a
+  sha: 404b5858f50a98811ccf2f39c0bedfa0d7753c76
 uaa/apache-tomcat-9.0.30.tar.gz:
   size: 11026056
   object_id: 0556fdf6-9a6a-4d4f-4967-c6787df4452c

--- a/packages/uaa/packaging
+++ b/packages/uaa/packaging
@@ -3,7 +3,7 @@
 set -e -x
 
 cd ${BOSH_INSTALL_TARGET}
-mkdir jdk && tar zxvf ${BOSH_COMPILE_TARGET}/openjdk/openjdk-*-x86_64-trusty.tar.gz -C jdk
+mkdir jdk && tar zxvf ${BOSH_COMPILE_TARGET}/openjdk/openjdk-*-x86_64-bionic.tar.gz -C jdk
 if [[ $? != 0 ]] ; then
   echo "Cannot unpack JDK"
   exit 1

--- a/packages/uaa/pre_packaging
+++ b/packages/uaa/pre_packaging
@@ -11,7 +11,7 @@ export PATH=$PATH:/bin:/usr/bin
 if [ `uname` = "Linux" ]; then
   mkdir java
   cd java
-  tar zxvf ../openjdk/openjdk-*-x86_64-trusty.tar.gz
+  tar zxvf ../openjdk/openjdk-*-x86_64-bionic.tar.gz
   export JAVA_HOME=${BUILD_DIR}/java
 else
   if [ ! -d $JAVA_HOME ]; then

--- a/packages/uaa/spec
+++ b/packages/uaa/spec
@@ -3,4 +3,4 @@ name: uaa
 dependencies:
 files:
 - uaa/**/*
-- openjdk/openjdk-*-x86_64-trusty.tar.gz
+- openjdk/openjdk-*-x86_64-bionic.tar.gz


### PR DESCRIPTION
I need help determining the `object_id` in `configs/blob.yml`. There may be other mistakes as well.

Trusty is no longer supported upstream in cloudfoundry/buildpack: https://github.com/cloudfoundry/java-buildpack/commit/c98dd6b6599057e7861f94fa91bc97beb68edf89


This addresses vulnerability in #167 