### PR TITLE
Deprecate uaa.ldap.sslCertificate

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -815,7 +815,7 @@ properties:
     description: "Used with search-and-compare only. The encoder used to properly encode user password to match the one in the LDAP directory."
     default: "org.cloudfoundry.identity.uaa.ldap.DynamicPasswordComparator"
   uaa.ldap.sslCertificate:
-    description: "Used with ldaps:// URLs. The certificate, if self signed, to be trusted by this connection."
+    description: "Deprecated. Use uaa.ca_certs."
   uaa.ldap.ssl.skipverification:
     description: "Set to true, and LDAPS connection will not validate the server certificate."
     default: false

--- a/jobs/uaa/templates/config/uaa.yml.erb
+++ b/jobs/uaa/templates/config/uaa.yml.erb
@@ -504,9 +504,6 @@
       },
       'addShadowUserOnLogin' => p('uaa.ldap.add_shadow_user_on_login')
     }
-    unless p_opt('uaa.ldap.sslCertificate').nil?
-      ldap['ssl']['sslCertificate'] = p_opt('uaa.ldap.sslCertificate')
-    end
     if p_opt('uaa.ldap.profile_type') == 'simple-bind'
       ldap['base']['userDnPattern'] = p_opt('uaa.ldap.userDNPattern')
       ldap['base']['userDnPatternDelimiter'] = p_opt('uaa.ldap.userDNPatternDelimiter')

--- a/spec/compare/all-properties-set-uaa.yml
+++ b/spec/compare/all-properties-set-uaa.yml
@@ -209,7 +209,6 @@ ldap:
   ssl:
     tls: simple
     skipverification: true
-    sslCertificate: ldap-ssl-cert
   base:
     url: ldap://192.168.50.4:389/
     mailAttributeName: mail

--- a/spec/input/all-properties-set.yml
+++ b/spec/input/all-properties-set.yml
@@ -537,7 +537,6 @@ properties:
       ssl:
         skipverification: true
         tls: simple
-      sslCertificate: ldap-ssl-cert
       storeCustomAttributes: false
       url: ldap://192.168.50.4:389/
       userDN: cn=admin,dc=test,dc=com


### PR DESCRIPTION
Behavior is identical to uaa.ca_certs and it should be used
instead for clarity.

Usage of uaa.ldap.sslCertificate has been removed from
uaa.yml, although this property was not actually used
by UAA.

This should be a non-breaking change. uaa.ldap.sslCertificate is still added to the cert store as before.