### PR TITLE
Add possibility to configure http client

### DIFF
--- a/jobs/uaa/templates/config/uaa.yml.erb
+++ b/jobs/uaa/templates/config/uaa.yml.erb
@@ -673,6 +673,12 @@
     add_value(params, login_defaultIdentityProvider, 'login', 'defaultIdentityProvider')
   end
 
+  if_p('uaa.rest.template') do |rest_template|
+    rest_template.each do |key,val|
+      add_value(params, val, 'rest','template', key)
+    end
+  end
+
   if_p('login.links') do |login_links|
     login_links.each do |key,val|
       add_value(params, val, 'links', key)

--- a/spec/compare/all-properties-set-uaa.yml
+++ b/spec/compare/all-properties-set-uaa.yml
@@ -630,3 +630,10 @@ notifications:
 analytics:
   code: code
   domain: domain
+
+rest:
+  template:
+    timeout: 10000
+    maxTotal: 20
+    maxPerRoute: 2
+    maxKeepAlive: 0

--- a/spec/input/all-properties-set.yml
+++ b/spec/input/all-properties-set.yml
@@ -574,6 +574,12 @@ properties:
       - 127.1.0.3
     proxy_ips_regex: 10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}
     require_https: false
+    rest:
+      template:
+        timeout: 10000
+        maxTotal: 20
+        maxPerRoute: 2
+        maxKeepAlive: 0
     scim:
       external_groups:
         origin1:


### PR DESCRIPTION
As a follow-up for the new configuration options of the HttpClient in the uaa project, we need to expose those configuration options also via the uaa-release to make it available for such a deployment.