### PR TITLE
Feature: implement support for GitHub OAuth2 Identity Provider

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,2 @@
-export GOPATH=~/workspace/uaa-release
-export PATH=~/workspace/uaa-release/bin:$PATH
+PATH_add bin
+export GOPATH=$PWD

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/uaa"]
 	path = src/uaa
-	url = https://github.com/cloudfoundry/uaa.git
+	url = https://github.com/gstackio/uaa.git

--- a/ci/.gitignore
+++ b/ci/.gitignore
@@ -1,0 +1,1 @@
+secrets.yml

--- a/ci/config.yml
+++ b/ci/config.yml
@@ -1,0 +1,6 @@
+---
+github_username: gk-concourse-ninja
+
+git_user_name: Gstack Concourse Ninja
+
+traefik_release_git_uri: git@github.com:gstackio/traefik-boshrelease.git

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,0 +1,561 @@
+---
+#
+# ci/pipeline.yml
+#
+# Pipeline structure file for a BOSH Release pipeline
+#
+# DO NOT MAKE CHANGES TO THIS FILE.  Instead, modify
+# ci/settings.yml and override what needs overridden.
+# This uses spruce, so you have some options there.
+#
+# author:  James Hunt <james@niftylogic.com>
+# created: 2016-03-30
+
+meta:
+  name:     (( param "Please name your pipeline" ))
+  release:  (( grab meta.name ))
+  target:   (( param "Please identify the name of the target Concourse CI" ))
+  url:      (( param "Please specify the full url of the target Concourse CI" ))
+  pipeline: (( concat meta.name "-boshrelease" ))
+  manifest:
+    path:   (( concat meta.manifest.directory "/" meta.name ".yml" ))
+    vars:   "--- {}"
+    vars-pr: (( grab meta.manifest.vars ))
+    operator_file_paths: "" # comma (or space) separated list relative to repo root
+
+  git:
+    email:  (( param "Please provide the git email for automated commits" ))
+    name:   (( param "Please provide the git name for automated commits" ))
+
+  image:
+    name: starkandwayne/concourse
+    tag: latest
+
+  aws:
+    bucket:     (( grab meta.pipeline ))
+    region_name: us-east-1
+    access_key: (( param "Please set your AWS Access Key ID for your pipeline S3 Bucket" ))
+    secret_key: (( param "Please set your AWS Secret Key ID for your pipeline S3 Bucket" ))
+
+  github:
+    uri:          (( concat "git@github.com:" meta.github.owner "/" meta.github.repo ))
+    owner:        (( param "Please specify the name of the user / organization that owns the Github repository" ))
+    repo:         (( param "Please specify the name of the Github repository" ))
+    branch:       master
+    private_key:  (( param "Please generate an SSH Deployment Key for this repo and specify it here" ))
+    access_token: (( param "Please generate a Personal Access Token to be used for creating github releases (do you have a ci-bot?)" ))
+
+  bosh:
+    stemcell:
+      major: 621
+      cpi: aws-xen-hvm
+      os: ubuntu-xenial
+    target:        ((bosh-lite-environment))
+    cacert:        ((bosh-lite-ca-cert))
+    username:      ((bosh-lite-client))
+    password:      ((bosh-lite-client-secret))
+    deployment:    (( concat meta.name "-testflight" ))
+    deployment-pr: (( concat meta.name "-testflight-pr" ))
+
+  slack:
+    webhook:       (( param "Please specify your Slack Incoming Webhook Integration URL" ))
+    success_moji:  ":airplane_departure:"
+    fail_moji:     ":airplane_arriving:"
+    upset_moji:    ":sad_panda:"
+    channel:       (( param "Please specify the channel (#name) or user (@user) to send messages to" ))
+    username:      concourse
+    icon:          https://cl.ly/2F421Y300u07/concourse-logo-blue-transparent.png
+    fail_url: '(( concat "<" meta.url "/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME| Concourse Failure! " meta.slack.upset_moji ">" ))'
+
+groups:
+  - name: (( grab meta.pipeline ))
+    jobs:
+      - testflight
+      - testflight-pr
+      - pre
+      - rc
+      - shipit
+  - name: versioning
+    jobs:
+      - major
+      - minor
+      - patch
+  - name: compiled-releases
+    jobs:
+      - compile-release
+      - use-compiled-releases
+
+jobs:
+  - name: testflight
+    public: true
+    serial: true
+    plan:
+    - name: main
+      do:
+      - { get: git, trigger: true }
+      - { get: image }
+      - name: testflight
+        task: testflight
+        image: image
+        config:
+          platform: linux
+          inputs:
+            - { name: git }
+          run:
+            path: ./git/ci/scripts/testflight
+            args: []
+          params:
+            REPO_ROOT:            git
+            BOSH_ENVIRONMENT:     (( grab meta.bosh.target ))
+            BOSH_CA_CERT:         (( grab meta.bosh.cacert ))
+            BOSH_CLIENT:          (( grab meta.bosh.username ))
+            BOSH_CLIENT_SECRET:   (( grab meta.bosh.password ))
+            BOSH_DEPLOYMENT:      (( grab meta.bosh.deployment ))
+            TEST_ERRANDS:         (( grab meta.test-errands || meta.test-errand || ~ ))
+            AWS_ACCESS_KEY:       (( grab meta.aws.access_key ))
+            AWS_SECRET_KEY:       (( grab meta.aws.secret_key ))
+            MANIFEST_PATH:        (( grab meta.manifest.path ))
+            MANIFEST_VARS:        (( grab meta.manifest.vars ))
+            MANIFEST_OP_PATHS:    (( grab meta.manifest.operator_file_paths ))
+      on_failure:
+        put: notify
+        params:
+          channel:  (( grab meta.slack.channel ))
+          username: (( grab meta.slack.username ))
+          icon_url: (( grab meta.slack.icon ))
+          text:    '(( concat meta.slack.fail_url " " meta.pipeline ": testflight job failed" ))'
+
+  - name: testflight-pr
+    public: true
+    serial: true
+    plan:
+    - name: main
+      do:
+      - { get: git-pull-requests, trigger: true, version: every }
+      - { get: image }
+      - name: pending-status
+        put: git-pull-requests
+        params:
+          path: git-pull-requests
+          status: pending
+      - name: testflight
+        task: testflight
+        image: image
+        config:
+          platform: linux
+          inputs:
+            - { name: git-pull-requests }
+          run:
+            path: ./git-pull-requests/ci/scripts/testflight
+            args: []
+          params:
+            REPO_ROOT:            git-pull-requests
+            BOSH_ENVIRONMENT:     (( grab meta.bosh.target ))
+            BOSH_CA_CERT:         (( grab meta.bosh.cacert ))
+            BOSH_CLIENT:          (( grab meta.bosh.username ))
+            BOSH_CLIENT_SECRET:   (( grab meta.bosh.password ))
+            BOSH_DEPLOYMENT:      (( grab meta.bosh.deployment-pr ))
+            TEST_ERRANDS:         (( grab meta.test-errands || meta.test-errand || ~ ))
+            AWS_ACCESS_KEY:       (( grab meta.aws.access_key ))
+            AWS_SECRET_KEY:       (( grab meta.aws.secret_key ))
+            MANIFEST_PATH:        (( grab meta.manifest.path ))
+            MANIFEST_VARS:        (( grab meta.manifest.vars-pr ))
+            MANIFEST_OP_PATHS:    (( grab meta.manifest.operator_file_paths ))
+        on_success:
+          put: git-pull-requests
+          params:
+            path: git-pull-requests
+            status: success
+        on_failure:
+          put: git-pull-requests
+          params:
+            path: git-pull-requests
+            status: failure
+      - name: pr-success-message
+        task: pr-success-message
+        image: image
+        config:
+          platform: linux
+          inputs:
+            - { name: git-pull-requests }
+          outputs:
+            - { name: message }
+          run:
+            path: sh
+            args:
+            - -ce
+            - |
+              cd git-pull-requests
+              pr_url=$(git config --get pullrequest.url)
+              cd -
+              echo "<${pr_url}|Pull request passed testflight> Merge when ready: ${pr_url}" > message/body
+      on_success:
+        put: notify
+        params:
+          channel:  (( grab meta.slack.channel ))
+          username: (( grab meta.slack.username ))
+          icon_url: (( grab meta.slack.icon ))
+          text_file: message/body
+
+  - name: pre
+    public: true
+    serial: true
+    plan:
+    - do:
+      - get: git
+        passed:
+        - testflight
+        trigger: true
+      - get: version
+        trigger: true
+      - { get: image, passed: [testflight] }
+      - task: release-notes
+        image: image
+        config:
+          platform: linux
+          run:
+            path: sh
+            args:
+            - -ce
+            - |
+              cd git
+              if [ -f ci/release_notes.md ]; then
+                echo "######   RELEASE NOTES   ###############"
+                echo
+                cat ci/release_notes.md
+                echo
+                echo "########################################"
+                echo
+              else
+                echo "NO RELEASE NOTES HAVE BEEN WRITTEN"
+                echo "You *might* want to do that before"
+                echo "hitting (+) on that shipit job..."
+                echo
+              fi
+          inputs:
+          - name: git
+      on_failure:
+        put: notify
+        params:
+          channel:  (( grab meta.slack.channel ))
+          username: (( grab meta.slack.username ))
+          icon_url: (( grab meta.slack.icon ))
+          link: https://pipes.starkandwayne.com/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+          message: release candidate job 'pre' failed (which is unusual).
+          ok: false
+
+  - name: rc
+    public: true
+    serial: true
+    plan:
+    - do:
+      - { get: git,     trigger: true,  passed: [pre] }
+      - { get: version, trigger: false, params: {pre: rc} }
+      - { get: image,                   passed: [pre] }
+      - task: release-notes
+        image: image
+        config:
+          platform: linux
+          inputs:
+              - { name: git }
+          run:
+            path: sh
+            args:
+            - -ce
+            - |
+              cd git
+              if [ -f ci/release_notes.md ]; then
+                echo "######   RELEASE NOTES   ###############"
+                echo
+                cat ci/release_notes.md
+                echo
+                echo "########################################"
+                echo
+              else
+                echo "NO RELEASE NOTES HAVE BEEN WRITTEN"
+                echo "You *might* want to do that before"
+                echo "hitting (+) on that shipit job..."
+                echo
+              fi
+      - put: version
+        params: {file: version/number}
+      on_failure:
+        put: notify
+        params:
+          channel:  (( grab meta.slack.channel ))
+          username: (( grab meta.slack.username ))
+          icon_url: (( grab meta.slack.icon ))
+          text:    '(( concat meta.slack.fail_url " " meta.pipeline ": rc job failed" ))'
+
+  - name: minor
+    public: true
+    plan:
+    - do:
+      - { get: version, trigger: false, params: {bump: minor} }
+      - { put: version,                 params: {file: version/number} }
+      on_failure:
+        put: notify
+        params:
+          channel:  (( grab meta.slack.channel ))
+          username: (( grab meta.slack.username ))
+          icon_url: (( grab meta.slack.icon ))
+          text:    '(( concat meta.slack.fail_url " " meta.pipeline ": minor job failed" ))'
+
+  - name: patch
+    public: true
+    plan:
+    - do:
+      - { get: version, trigger: false, params: {bump: patch} }
+      - { put: version,                 params: {file: version/number} }
+      on_failure:
+        put: notify
+        params:
+          channel:  (( grab meta.slack.channel ))
+          username: (( grab meta.slack.username ))
+          icon_url: (( grab meta.slack.icon ))
+          text:    '(( concat meta.slack.fail_url " " meta.pipeline ": patch job failed" ))'
+
+  - name: major
+    public: true
+    plan:
+    - do:
+      - { get: version, trigger: false, params: {bump: major} }
+      - { put: version,                 params: {file: version/number} }
+      on_failure:
+        put: notify
+        params:
+          channel:  (( grab meta.slack.channel ))
+          username: (( grab meta.slack.username ))
+          icon_url: (( grab meta.slack.icon ))
+          text:    '(( concat meta.slack.fail_url " " meta.pipeline ": major job failed" ))'
+
+  - name: shipit
+    public: true
+    serial: true
+    plan:
+    - do:
+      - { get: version, passed: [rc], params: {bump: final} }
+      - { get: git,     passed: [rc] }
+      - { get: image,   passed: [rc] }
+      - name: release
+        task: release
+        image: image
+        config:
+          platform: linux
+          inputs:
+            - name: version
+            - name: git
+          outputs:
+            - name: gh
+            - name: pushme
+            - name: notifications
+          run:
+            path: ./git/ci/scripts/shipit
+            args: []
+          params:
+            REPO_ROOT:    git
+            VERSION_FROM: version/number
+            RELEASE_ROOT: gh
+            REPO_OUT:     pushme
+            NOTIFICATION_OUT: notifications
+            BRANCH:        (( grab meta.github.branch ))
+            GITHUB_OWNER:  (( grab meta.github.owner ))
+            GIT_EMAIL:      (( grab meta.git.email ))
+            GIT_NAME:       (( grab meta.git.name ))
+            AWS_ACCESS_KEY:       (( grab meta.aws.access_key ))
+            AWS_SECRET_KEY:       (( grab meta.aws.secret_key ))
+            MANIFESTS_DIR: (( grab meta.manifest.directory ))
+
+      - name: upload-git
+        put: git
+        params:
+          rebase: true
+          repository: pushme
+      - name: tarball
+        put: s3-tarball
+        params:
+          file:  (( concat "gh/artifacts/" meta.name "-*.tgz" ))
+      - name: github-release
+        put: github
+        params:
+          name:   gh/name
+          tag:    gh/tag
+          body:   gh/notes.md
+          globs: [gh/artifacts/*]
+      - name: version-bump
+        put: version
+        params:
+          bump: patch
+      - name: notify
+        put: notify
+        params:
+          channel:  (( grab meta.slack.channel ))
+          username: (( grab meta.slack.username ))
+          icon_url: (( grab meta.slack.icon ))
+          text_file: notifications/message
+      on_failure:
+        put: notify
+        params:
+          channel:  (( grab meta.slack.channel ))
+          username: (( grab meta.slack.username ))
+          icon_url: (( grab meta.slack.icon ))
+          text:    '(( concat meta.slack.fail_url " " meta.pipeline ": shipit job failed" ))'
+
+  - name: compile-release
+    old_name: compile-release-456
+    plan:
+      - get: git
+      - get: github
+        trigger: true
+      - get: (( concat meta.bosh.stemcell.os "-stemcell-" meta.bosh.stemcell.major ))
+        params: {tarball: false}
+      - { get: image }
+      - task: export-release
+        image: image
+        config:
+          platform: linux
+          inputs:
+            - name: git
+            - name: (( concat meta.bosh.stemcell.os "-stemcell-" meta.bosh.stemcell.major ))
+              path: stemcell
+            - name: github
+              path: release
+          outputs:
+            - name: compiled-release
+          run:
+            path: git/ci/scripts/export-release
+          params:
+            BOSH_ENVIRONMENT:     (( grab meta.bosh.target ))
+            BOSH_CA_CERT:         (( grab meta.bosh.cacert ))
+            BOSH_CLIENT:          (( grab meta.bosh.username ))
+            BOSH_CLIENT_SECRET:   (( grab meta.bosh.password ))
+            STEMCELL_CPI:         (( grab meta.bosh.stemcell.cpi ))
+            STEMCELL_OS:          (( grab meta.bosh.stemcell.os ))
+      - put: compiled-release
+        params:
+          file: (( concat "compiled-release/compiled-releases/" meta.name "/*.tgz" ))
+
+  - name: use-compiled-releases
+    plan:
+      - name: resources
+        in_parallel:
+          steps:
+            - get: git
+            - get: github
+              passed: [compile-release]
+              trigger: true
+            - get: (( concat meta.bosh.stemcell.os "-stemcell-" meta.bosh.stemcell.major ))
+              passed: [compile-release]
+              params: {tarball: false}
+            - get: compiled-release
+              passed: [compile-release]
+            - { get: image, passed: [compile-release] }
+      - task: use-compiled-releases
+        image: image
+        config:
+          platform: linux
+          inputs:
+            - name: git
+            - name: (( concat meta.bosh.stemcell.os "-stemcell-" meta.bosh.stemcell.major ))
+              path: stemcell
+            - name: github
+              path: release
+            - name: compiled-release
+          outputs:
+            - name: pushme
+          run:
+            path: git/ci/scripts/use-compiled-releases
+          params:
+            REPO_ROOT:     git
+            REPO_OUT:      pushme
+            GIT_EMAIL:     (( grab meta.git.email ))
+            GIT_NAME:      (( grab meta.git.name ))
+            BRANCH:        (( grab meta.github.branch ))
+            STEMCELL_OS:   (( grab meta.bosh.stemcell.os ))
+            MANIFESTS_DIR: (( grab meta.manifest.directory ))
+      - name: upload-git
+        put: git
+        params:
+          rebase: true
+          repository: pushme
+
+resource_types:
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+
+  - name: pull-request
+    type: docker-image
+    source:
+      repository: jtarchie/pr
+
+resources:
+  - name: image
+    type: docker-image
+    source:
+      repository: (( grab meta.image.name ))
+      tag:        (( grab meta.image.tag ))
+
+  - name: git
+    type: git
+    source:
+      uri:         (( grab meta.github.uri ))
+      branch:      (( grab meta.github.branch ))
+      private_key: (( grab meta.github.private_key ))
+
+  - name: git-pull-requests
+    type: pull-request
+    check_every: 15m # Required due to API throttling.
+    source:
+      access_token: (( grab meta.github.access_token ))
+      private_key:  (( grab meta.github.private_key ))
+      repo:         (( concat meta.github.owner "/" meta.github.repo ))
+      base:         (( grab meta.github.branch ))
+
+  - name: version
+    type: semver
+    source :
+      driver:            s3
+      bucket:            (( grab meta.aws.bucket ))
+      region_name:       (( grab meta.aws.region_name ))
+      key:               version
+      access_key_id:     (( grab meta.aws.access_key ))
+      secret_access_key: (( grab meta.aws.secret_key ))
+      initial_version:   (( grab meta.initial_version || "0.0.1" ))
+
+  - name: notify
+    type: slack-notification
+    source:
+      url: (( grab meta.slack.webhook ))
+
+  - name: github
+    type: github-release
+    source:
+      user:         (( grab meta.github.owner ))
+      repository:   (( grab meta.github.repo ))
+      access_token: (( grab meta.github.access_token ))
+
+  - name: s3-tarball
+    type: s3
+    source:
+      bucket:            (( grab meta.aws.bucket ))
+      region_name:       (( grab meta.aws.region_name ))
+      regexp:            (( concat meta.name "-(.*).tgz" ))
+      access_key_id:     (( grab meta.aws.access_key ))
+      secret_access_key: (( grab meta.aws.secret_key ))
+
+  - name: (( concat meta.bosh.stemcell.os "-stemcell-" meta.bosh.stemcell.major ))
+    type: bosh-io-stemcell
+    source:
+      name: (( concat "bosh-" meta.bosh.stemcell.cpi "-" meta.bosh.stemcell.os "-go_agent" ))
+      version_family: (( concat meta.bosh.stemcell.major ".latest" ))
+
+  - name: compiled-release
+    type: s3
+    source:
+      bucket:            (( grab meta.aws.bucket ))
+      region_name:       (( grab meta.aws.region_name ))
+      access_key_id:     (( grab meta.aws.access_key ))
+      secret_access_key: (( grab meta.aws.secret_key ))
+      regexp:            (( concat "compiled-releases/" meta.name "/.*-(\\d+).tgz" ))

--- a/ci/repipe
+++ b/ci/repipe
@@ -1,0 +1,151 @@
+#!/bin/bash
+#
+# ci/repipe
+#
+# Script for merging together pipeline configuration files
+# (via Spruce!) and configuring Concourse.
+#
+# author:  James Hunt <james@niftylogic.com>
+#          Dennis Bell <dennis.j.bell@gmail.com>
+# created: 2016-03-04
+
+need_command() {
+	local cmd=${1:?need_command() - no command name given}
+
+	if [[ ! -x "$(command -v $cmd)" ]]; then
+		echo >&2 "${cmd} is not installed."
+		if [[ "${cmd}" == "spruce" ]]; then
+			echo >&2 "Please download it from https://github.com/geofffranks/spruce/releases"
+		fi
+		exit 2
+	fi
+}
+
+NO_FLY=
+SAVE_MANIFEST=
+VALIDATE_PIPELINE=
+NON_INTERACTIVE=
+
+cleanup() {
+    rm -f save-manifest.yml
+    if [[ -n ${SAVE_MANIFEST} && -e .deploy.yml ]]; then
+        mv .deploy.yml save-manifest.yml
+    fi
+    rm -f .deploy.yml
+}
+
+usage() {
+    echo Command line arguments:
+    echo "no-fly            Do not execute any fly commands"
+    echo "save-manifest     Save manifest to file save-manifest"
+    echo "validate          Validate pipeline instead of set pipeline"
+    echo "validate-strict   Validate pipeline with strict mode"
+    echo "non-interactive   Run set-pipeline in non-interactive mode"
+    echo "open              Open pipeline dashboard to browser (if possible)"
+}
+
+open_pipeline() {
+	url=$(show_pipeline_url)
+    cleanup
+	if [[ -x /usr/bin/open ]]; then
+		exec /usr/bin/open "$url"
+	else
+		echo "Sorry, but I was not able to automagically open"
+		echo "your Concourse Pipeline in the browser."
+		echo
+		echo "Here's a link you can click on, though:"
+		echo
+		echo "  $url"
+		echo
+		exit 0;
+	fi
+}
+
+show_pipeline_url() {
+	spruce merge --skip-eval pipeline.yml ${settings_file} > .deploy.yml
+	concourse_url=$(spruce json .deploy.yml | jq -r ".meta.url")
+	team=$(spruce json .deploy.yml | jq -r ".meta.team // \"main\"")
+	pipeline=$(spruce merge --skip-eval \
+		--cherry-pick meta.pipeline \
+		--cherry-pick meta.name \
+		.deploy.yml | spruce merge - | spruce json | jq -r ".meta.pipeline")
+
+	echo "$concourse_url/teams/$team/pipelines/$pipeline"
+	exit 0
+}
+
+for arg do
+    case "${arg}" in
+        no-fly|no_fly)  NO_FLY="yes" ;;
+        save-manifest|save_manifest) SAVE_MANIFEST="yes" ;;
+        validate) VALIDATE_PIPELINE="normal" ;;
+        validate-strict|validate_strict) VALIDATE_PIPELINE="strict" ;;
+        non-interactive|non_interactive) NON_INTERACTIVE="--non-interactive" ;;
+        url) SHOW_PIPELINE_URL="yes" ;;
+        open) OPEN_PIPELINE="yes" ;;
+        help|-h|--help) usage; exit 0 ;;
+        *) echo Invalid argument
+            usage
+            exit 1
+    esac
+done
+
+cd $(dirname $BASH_SOURCE[0])
+echo >&2 "Working in $(pwd)"
+need_command spruce
+
+# Allow for target-specific settings
+settings_file="$(ls -1 settings.yml ${CONCOURSE_TARGET:+"settings-${CONCOURSE_TARGET}.yml"} 2>/dev/null | tail -n1)"
+if [[ -z "$settings_file" ]]
+then
+  echo >&2 "Missing local settings in ci/settings.yml${CONCOURSE_TARGET:+" or ci/settings-${CONCOURSE_TARGET}.yml"}!"
+  exit 1
+fi
+
+echo >&2 "Using settings found in ${settings_file}"
+
+set -e
+trap "cleanup" QUIT TERM EXIT INT
+
+[[ -n ${SHOW_PIPELINE_URL} ]] && { show_pipeline_url; exit 0; }
+[[ -n ${OPEN_PIPELINE} ]]     && { open_pipeline;     exit 0; }
+
+spruce merge pipeline.yml ${settings_file} > .deploy.yml
+PIPELINE=$(spruce json .deploy.yml | jq -r '.meta.pipeline // ""')
+if [[ -z ${PIPELINE} ]]; then
+	echo >&2 "Missing pipeline name in ci/settings.yml!"
+	exit 1
+fi
+
+TARGET_FROM_SETTINGS=$(spruce json .deploy.yml | jq -r '.meta.target // ""')
+if [[ -z ${CONCOURSE_TARGET} ]]; then
+  TARGET=${TARGET_FROM_SETTINGS}
+elif [[ "$CONCOURSE_TARGET" != "$TARGET_FROM_SETTINGS" ]]
+then
+  echo >&2 "Target in {$settings_file} differs from target in \$CONCOURSE_TARGET"
+  echo >&2 "  \$CONCOURSE_TARGET: $CONCOURSE_TARGET"
+  echo >&2 "  Target in file:    $TARGET_FROM_SETTINGS"
+  exit 1
+else
+  TARGET=${CONCOURSE_TARGET}
+fi
+
+if [[ -z ${TARGET} ]]; then
+	echo >&2 "Missing Concourse Target in ci/settings.yml!"
+	exit 1
+fi
+
+fly_cmd="${FLY_CMD:-fly}"
+
+[[ -n ${NO_FLY} ]] && { echo no fly execution requested ; exit 0; }
+
+case "${VALIDATE_PIPELINE}" in
+    normal) fly_opts="validate-pipeline" ;;
+    strict) fly_opts="validate-pipeline --strict" ;;
+    *) fly_opts="set-pipeline ${NON_INTERACTIVE} --pipeline ${PIPELINE}" ;;
+esac
+
+set +x
+$fly_cmd --target ${TARGET} ${fly_opts} --config .deploy.yml
+[[ -n ${VALIDATE_PIPELINE} ]] && exit 0
+$fly_cmd --target ${TARGET} unpause-pipeline --pipeline ${PIPELINE}

--- a/ci/scripts/bump-dependent-release
+++ b/ci/scripts/bump-dependent-release
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# The goal of this script is to retain the pretty nature of manifests, whilst updating
+# the "releases:" section.
+#
+# If we use `spruce merge` to do the job, the entire manifest will be reordered -
+# keys will be sorted alphabetically. Comments will be lost.
+#
+# Instead, we assume that "releases:" is the last section of the manifest.
+set -e
+
+: ${REPO_ROOT:?required}
+: ${REPO_OUT:?required}
+: ${RELEASE:?required}
+: ${NAME:?required}
+
+if [[ ! -f ${RELEASE}/version ]]; then
+  echo "Director ${RELEASE} must have file /version"
+  exit 1
+fi
+
+git clone ${REPO_ROOT} ${REPO_OUT}
+
+version=$(cat ${RELEASE}/version)
+
+# So, this is a nested bash/spruce/jq combo.
+# What is happening here is that the "releases:" section of each deployment manifest
+# is being updated with the new version/sha1 for the release.
+#
+# We use "spruce json manifest.yml | jq '.releases'" to extract the existing releases array
+# and the '.releases | map(if .name == $name)' will modify a specific element of the array
+#
+# This gives us a modified "releases: [{...}, {...}]" segment of the final deployment manifest.
+# We now need to merge this back into the original manifest.
+#
+# But, I don't want to just use `spruce merge` for this as it will reorder the manifest and
+# make it ugly. If I didn't care about the manifest's aesthetics then this whole script
+# would be simpler. I want the original layout of the manifest to be retained; and so
+# we will just chomp out the original "releases:" section at the end of the file and
+# paste in the updated releases section.
+function bump_version {
+  manifest_path=$1
+  releases_updated=$(spruce merge <<YAML
+releases: $(spruce json "$manifest_path" | jq --arg name $NAME --arg version $version '.releases | map(
+    if .name == $name
+    then . + {"version":$version}
+    else .
+    end)'
+)
+YAML
+)
+  releases_line_number=$(awk '/^releases:/{ print NR; exit }' $manifest_path)
+  manifest_head=$(head -n `expr $releases_line_number - 1` $manifest_path)
+  cat > $manifest_path <<YAML
+${manifest_head}
+
+${releases_updated}
+YAML
+}
+
+cd ${REPO_OUT}
+for manifest_path in $(ls manifests/*.yml); do
+  bump_version $manifest_path
+done
+
+cat <<EOF >>ci/release_notes.md
+* Bumped ${NAME} to v${version}
+EOF
+
+
+if [[ -z $(git config --global user.email) ]]; then
+  git config --global user.email "${GIT_EMAIL}"
+fi
+if [[ -z $(git config --global user.name) ]]; then
+  git config --global user.name "${GIT_NAME}"
+fi
+
+git merge --no-edit ${BRANCH}
+git add -A
+git status
+git commit -m "bump ${NAME} v${version}"

--- a/ci/scripts/export-release
+++ b/ci/scripts/export-release
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -eu
+
+: ${BOSH_ENVIRONMENT:?required}
+: ${BOSH_CA_CERT:?required}
+: ${BOSH_CLIENT:?required}
+: ${BOSH_CLIENT_SECRET:?required}
+
+#
+# stemcell metadata/upload
+#
+
+STEMCELL_CPI=${STEMCELL_CPI:-aws-xen-hvm}
+STEMCELL_OS=${STEMCELL_OS:-ubuntu-xenial}
+STEMCELL_VERSION=$(cat stemcell/version)
+
+if [[ $(bosh stemcells --json | jq -r ".Tables[0].Rows[] | select(.os == \"${STEMCELL_OS}\") | .version | test(\"${STEMCELL_VERSION}\")" | grep true | uniq) != "true" ]]; then
+  #                        https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3586.7
+  bosh -n upload-stemcell "https://bosh.io/d/stemcells/bosh-${STEMCELL_CPI}-${STEMCELL_OS}-go_agent?v=${STEMCELL_VERSION}"
+fi
+
+#
+# release metadata/upload
+#
+
+cd release
+tar -xzf *.tgz $( tar -tzf *.tgz | grep 'release.MF' )
+RELEASE_NAME=$( grep -E '^name: ' release.MF | awk '{print $2}' | tr -d "\"'" )
+RELEASE_VERSION=$( grep -E '^version: ' release.MF | awk '{print $2}' | tr -d "\"'" )
+
+bosh -n upload-release *.tgz
+cd ../
+
+#
+# compilation deployment
+#
+
+cat > manifest.yml <<EOF
+---
+name: compilation-${RELEASE_NAME}
+releases:
+- name: "$RELEASE_NAME"
+  version: "$RELEASE_VERSION"
+stemcells:
+- alias: default
+  os: "$STEMCELL_OS"
+  version: "$STEMCELL_VERSION"
+update:
+  canaries: 1
+  max_in_flight: 1
+  canary_watch_time: 1000 - 90000
+  update_watch_time: 1000 - 90000
+instance_groups: []
+EOF
+
+export BOSH_DEPLOYMENT="compilation-${RELEASE_NAME}"
+
+delete_compilation_deployment() {
+	echo "Cleaning up deployment..."
+	bosh -n delete-deployment --force
+}
+trap "echo; echo; echo; sleep 10; delete_compilation_deployment" EXIT SIGINT SIGTERM
+
+
+bosh -n deploy manifest.yml
+bosh    export-release $RELEASE_NAME/$RELEASE_VERSION $STEMCELL_OS/$STEMCELL_VERSION
+
+mkdir -p compiled-release/compiled-releases/$RELEASE_NAME
+mv *.tgz compiled-release/compiled-releases/$RELEASE_NAME/$( echo *.tgz | sed "s/\.tgz$/-$( date -u +%Y%m%d%H%M%S ).tgz/" )
+sha1sum  compiled-release/compiled-releases/$RELEASE_NAME/*.tgz

--- a/ci/scripts/shipit
+++ b/ci/scripts/shipit
@@ -1,0 +1,121 @@
+#!/bin/bash
+#
+# ci/scripts/shipit
+#
+# Script for generating Github release / tag assets
+# and managing release notes for a BOSH Release pipeline
+#
+# author:  James Hunt <james@niftylogic.com>
+# created: 2016-03-30
+
+set -eu
+
+header() {
+	echo
+	echo "###############################################"
+	echo
+	echo $*
+	echo
+}
+
+: ${REPO_ROOT:?required}
+: ${RELEASE_ROOT:?required}
+: ${REPO_OUT:?required}
+: ${BRANCH:?required}
+: ${GITHUB_OWNER:?required}
+: ${VERSION_FROM:?required}
+: ${AWS_ACCESS_KEY:?required}
+: ${AWS_SECRET_KEY:?required}
+: ${GIT_EMAIL:?required}
+: ${GIT_NAME:?required}
+
+if [[ ! -f ${VERSION_FROM} ]]; then
+  echo >&2 "Version file (${VERSION_FROM}) not found.  Did you misconfigure Concourse?"
+  exit 2
+fi
+VERSION=$(cat ${VERSION_FROM})
+if [[ -z ${VERSION} ]]; then
+  echo >&2 "Version file (${VERSION_FROM}) was empty.  Did you misconfigure Concourse?"
+  exit 2
+fi
+
+if [[ ! -f ${REPO_ROOT}/ci/release_notes.md ]]; then
+  echo >&2 "ci/release_notes.md not found.  Did you forget to write them?"
+  exit 1
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+###############################################################
+
+git clone ${REPO_ROOT} ${REPO_OUT}
+
+pushd ${REPO_OUT}
+RELEASE_NAME=$(bosh int config/final.yml --path /final_name 2> /dev/null) \
+  || RELEASE_NAME=$(bosh int config/final.yml --path /name)
+
+cat > config/private.yml <<YAML
+---
+blobstore:
+  provider: s3
+  options:
+    access_key_id: ${AWS_ACCESS_KEY}
+    secret_access_key: ${AWS_SECRET_KEY}
+YAML
+
+header "Pulling in any git submodules..."
+git submodule update --init --recursive --force
+
+header "Create final release..."
+bosh -n create-release --final --version "${VERSION}"
+bosh -n create-release releases/$RELEASE_NAME/$RELEASE_NAME-$VERSION.yml \
+              --tarball releases/$RELEASE_NAME/$RELEASE_NAME-$VERSION.tgz
+popd
+
+RELEASE_TGZ=$REPO_OUT/releases/$RELEASE_NAME/$RELEASE_NAME-$VERSION.tgz
+export RELEASE_SHA1=$(sha1sum $RELEASE_TGZ | head -n1 | awk '{print $1}')
+export RELEASE_URL="https://github.com/${GITHUB_OWNER}/${RELEASE_NAME}-boshrelease/releases/download/v${VERSION}/${RELEASE_NAME}-${VERSION}.tgz"
+echo "RELEASE_SHA1=$RELEASE_SHA1"
+
+mkdir -p ${RELEASE_ROOT}/artifacts
+echo "v${VERSION}"                         > ${RELEASE_ROOT}/tag
+echo "v${VERSION}"                         > ${RELEASE_ROOT}/name
+mv ${REPO_OUT}/releases/*/*-${VERSION}.tgz   ${RELEASE_ROOT}/artifacts
+mv ${REPO_OUT}/ci/release_notes.md           ${RELEASE_ROOT}/notes.md
+cat >> ${RELEASE_ROOT}/notes.md <<EOF
+
+### Deployment
+
+\`\`\`yaml
+releases:
+- name:    $RELEASE_NAME
+  version: $VERSION
+  url:     $RELEASE_URL
+  sha1:    $RELEASE_SHA1
+\`\`\`
+EOF
+cat > ${RELEASE_ROOT}/notification <<EOF
+<!here> New ${RELEASE_NAME} v${VERSION} released!
+EOF
+
+
+header "Update git repo with final release..."
+if [[ -z $(git config --global user.email) ]]; then
+  git config --global user.email "${GIT_EMAIL}"
+fi
+if [[ -z $(git config --global user.name) ]]; then
+  git config --global user.name "${GIT_NAME}"
+fi
+
+pushd $REPO_OUT
+$DIR/update-manifest-release $RELEASE_NAME $VERSION $RELEASE_URL $RELEASE_SHA1
+
+git merge --no-edit ${BRANCH}
+git add -A
+git status
+git commit -m "release v${VERSION}"
+popd
+
+cat > ${NOTIFICATION_OUT:-notifications}/message <<EOS
+New ${RELEASE_NAME} v${VERSION} released. <https://github.com/${GITHUB_OWNER}/${RELEASE_NAME}-boshrelease/releases/tag/v${VERSION}|Release notes>.
+EOS

--- a/ci/scripts/testflight
+++ b/ci/scripts/testflight
@@ -1,0 +1,171 @@
+#!/bin/bash
+#
+# ci/scripts/testflight
+#
+# Script for testing a BOSH release using bosh
+#
+# author:  James Hunt <james@niftylogic.com>
+
+set -eu
+
+: ${BOSH_ENVIRONMENT:?required}
+: ${BOSH_CA_CERT:?required}
+: ${BOSH_CLIENT:?required}
+: ${BOSH_CLIENT_SECRET:?required}
+: ${BOSH_DEPLOYMENT:?required}
+: ${MANIFEST_PATH:?required}
+: ${AWS_ACCESS_KEY:?required}
+: ${AWS_SECRET_KEY:?required}
+DEBUG=${DEBUG:-}
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+header() {
+	echo
+	echo "###############################################"
+	echo
+	echo $*
+	echo
+}
+
+delete_deployment() {
+	header "Cleaning up deployment..."
+	bosh -n delete-deployment --force
+}
+trap "echo; echo; echo; sleep 10; delete_deployment" EXIT SIGINT SIGTERM
+
+
+cd ${REPO_ROOT:?required}
+header "Pulling in any git submodules..."
+git submodule update --init --recursive --force
+
+header "Confirming testflight inputs"
+
+echo "Confirming deployment manifest ${MANIFEST_PATH} exists"
+if [[ ! -f ${MANIFEST_PATH} ]]; then
+	echo "Deployment manifest ${MANIFEST_PATH} does not exist"
+	exit 1
+fi
+
+echo "Confirming that \$MANIFEST_VARS is valid"
+mkdir -p tmp
+
+# $MANIFEST_VARS can either be "key: value" or "key=value"
+# and will be converted to "key: value" YAML
+echo "${MANIFEST_VARS:-"{} ---"}" | sed -e "s/ *= */: /g" > tmp/vars.yml
+if [[ ! -z $DEBUG ]]; then
+	echo "Variables passed to deployment manifest:"
+	cat tmp/vars.yml
+fi
+# convert YAML to JSON to check YAML validity
+spruce json tmp/vars.yml > /dev/null
+
+echo "Confirming each operator file exists: ${MANIFEST_OP_PATHS:-ok, none specified.}"
+op_patch_file_errors=
+for op_patch_file in ${MANIFEST_OP_PATHS//,/ } ; do
+	if [[ ! -f $op_patch_file ]]; then
+		op_patch_file_errors=1
+		echo "Operator file missing: ${op_patch_file}"
+	fi
+done
+if [[ ! -z ${op_patch_file_errors} ]]; then
+	exit 1
+fi
+
+$DIR/wait-until-proxy-bosh-cf-running
+if [[ "${PROXY_IP:-X}" != "X" ]] ; then export BOSH_ALL_PROXY=socks5://localhost:9999 ; fi
+
+delete_deployment
+
+header "Creating candidate BOSH release..."
+bosh -n reset-release # in case dev_releases/ is in repo accidentally
+
+cat > config/private.yml <<YAML
+---
+blobstore:
+  provider: s3
+  options:
+    access_key_id: ${AWS_ACCESS_KEY}
+    secret_access_key: ${AWS_SECRET_KEY}
+YAML
+bosh create-release
+bosh upload-release --rebase
+
+header "Deploying to ${BOSH_ENVIRONMENT}..."
+release_name=$(bosh int config/final.yml --path /final_name 2> /dev/null) \
+  || release_name=$(bosh int config/final.yml --path /name)
+
+header "Choosing cloud-config options"
+vm_type=$(bosh int <(bosh cloud-config) --path /vm_types/0/name)
+disk_type=$(bosh int <(bosh cloud-config) --path /disk_types/0/name)
+network=$(bosh int <(bosh cloud-config) --path /networks/0/name)
+
+release_final_version=$(spruce json dev_releases/*/index.yml | jq -r ".builds[].version" | sed -e "s%+.*%%")
+release_dev_version="${release_final_version}.latest"
+
+cat > tmp/deployment.yml <<YAML
+---
+- type: replace
+  path: /name
+  value: ${BOSH_DEPLOYMENT}
+
+- type: replace
+  path: /releases/name=${release_name}
+  value:
+    name: ${release_name}
+    version: ${release_dev_version}
+YAML
+
+for ig_name in $(spruce json ${MANIFEST_PATH} | jq -r ".instance_groups[].name"); do
+cat >> tmp/deployment.yml <<YAML
+- type: replace
+  path: /instance_groups/name=${ig_name}/vm_type
+  value: ${vm_type}
+
+- type: replace
+  path: /instance_groups/name=${ig_name}/networks
+  value: [{name: ${network}}]
+
+YAML
+done
+
+instance_groups_with_persistent_disk_types=$(spruce json $MANIFEST_PATH | jq -r ".instance_groups[] | select(.persistent_disk_type).name")
+for ig_name in $instance_groups_with_persistent_disk_types; do
+	cat >> tmp/deployment.yml <<YAML
+- type: replace
+  path: /instance_groups/name=${ig_name}/persistent_disk_type
+  value: ${disk_type}
+
+YAML
+done
+
+op_patch_files_flags=""
+for op_patch_file in ${MANIFEST_OP_PATHS//,/ } ; do
+   op_patch_files_flags="${op_patch_files_flags} -o $op_patch_file"
+done
+
+set -x
+
+bosh int ${MANIFEST_PATH} \
+  -o tmp/deployment.yml    \
+  ${op_patch_files_flags}            \
+  --vars-store tmp/creds.yml \
+  --vars-file  tmp/vars.yml  \
+  --var-errs \
+    > tmp/manifest.yml
+
+bosh -n deploy tmp/manifest.yml
+
+TEST_ERRAND=${TEST_ERRAND:-} # backwards compatibility
+TEST_ERRANDS=${TEST_ERRANDS:-$TEST_ERRAND}
+if [[ -n ${TEST_ERRANDS} ]]; then
+	for errand in ${TEST_ERRANDS}; do
+		header "Running '${errand}' errand"
+		bosh -n run-errand ${errand}
+	done
+else
+	echo "No test errands specified, skipping."
+fi
+
+echo
+echo "SUCCESS"
+exit 0

--- a/ci/scripts/update-blob
+++ b/ci/scripts/update-blob
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -e
+
+: ${BLOB_DIR:?required}
+: ${BLOB_NAME:?required}
+: ${BLOB_BINARY:?required}
+: ${BLOB_CLEANUP:?required}
+: ${BLOB_DESTINATION:?required}
+
+# if git-release, then look for tag
+# git describe --tags `git rev-list --tags --max-count=1`
+# then convert v2.23.0 to VERSION=2.23.0
+[[ -f ${BLOB_DIR}/version ]] || {
+  # Perhaps move this into helper script that creates a github-release style folder
+  pushd ${BLOB_DIR}
+  tag=$(git describe --tags `git rev-list --tags --max-count=1`)
+  popd
+  resource_dir=${BLOB_NAME}-${tag//v/}
+  git clone ${BLOB_DIR} ${resource_dir}
+  rm -rf ${resource_dir}/.git
+  echo ${tag}     > ${BLOB_DIR}/tag
+  echo ${tag//v/} > ${BLOB_DIR}/version
+  tar czf ${BLOB_DIR}/${BLOB_NAME}-${tag//v/}.tar.gz ${resource_dir}
+}
+VERSION=$(cat ${BLOB_DIR}/version)
+
+pushd ${REPO_ROOT:?required}
+
+cat <<EOF >config/private.yml
+---
+blobstore:
+  provider: s3
+  options:
+    access_key_id: ${AWS_ACCESS_KEY:?required}
+    secret_access_key: ${AWS_SECRET_KEY:?required}
+EOF
+
+blobs_to_remove=$(spruce json config/blobs.yml | jq -r "keys[] | select(test(\"${BLOB_CLEANUP}\"))")
+if [[ ! -z $blobs_to_remove ]]; then
+  echo "$blobs_to_remove" | xargs -L1 bosh remove-blob
+fi
+
+# expand ${VERSION} env var into file path
+eval "blob_destination=${BLOB_DESTINATION}"
+bosh add-blob ../${BLOB_DIR}/${BLOB_BINARY} "${blob_destination}"
+bosh -n upload-blobs
+rm config/private.yml
+popd
+
+if [[ -n "$(cd ${REPO_ROOT}; git status --porcelain)" ]]; then
+  pushd ${REPO_ROOT}
+  cat <<EOF >>ci/release_notes.md
+* Bumped ${BLOB_URL} to v${VERSION}
+EOF
+  popd
+
+  # GIT!
+  if [[ -z $(git config --global user.email) ]]; then
+    git config --global user.email "ci@starkandwayne.com"
+  fi
+  if [[ -z $(git config --global user.name) ]]; then
+    git config --global user.name "CI Bot"
+  fi
+
+  (cd ${REPO_ROOT}
+   git merge --no-edit ${BRANCH}
+   git add -A
+   git status
+   git commit -m "Bumped ${BLOB_NAME} to v${VERSION}")
+fi
+
+# so that future steps in the pipeline can push our changes
+cp -a ${REPO_ROOT} ${REPO_OUT}

--- a/ci/scripts/update-manifest-compiled-release
+++ b/ci/scripts/update-manifest-compiled-release
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# The goal of this script is to retain the pretty nature of manifests, whilst updating
+# the "releases:" section with a stemcell-restricted compiled release
+#
+# If we use `spruce merge` to do the job, the entire manifest will be reordered -
+# keys will be sorted alphabetically. Comments will be lost.
+#
+# Instead, we assume that "releases:" is the last section of the manifest.
+set -e
+
+NAME=$1
+VERSION=$2
+RELEASE_TGZ_URL=$3
+RELEASE_TGZ_SHA1=$4
+STEMCELL_OS=$5
+STEMCELL_VERSION=$6
+
+if [[ "${STEMCELL_VERSION:-X}" == "X" ]]; then
+  echo "USAGE: update-manifest-release NAME VERSION URL SHA1 STEMCELL_OS STEMCELL_VERSION"
+  exit 1
+fi
+: ${REPO_ROOT:?required}
+: ${REPO_OUT:?required}
+: ${MANIFESTS_DIR:?required}
+
+# So, this is a nested bash/spruce/jq combo.
+# What is happening here is that the "releases:" section of each deployment manifest
+# is being updated with the new version/sha1 for the release.
+#
+# We use "spruce json manifest.yml | jq '.releases'" to extract the existing releases array
+# and the '.releases | map(if .name == $name)' will modify a specific element of the array
+#
+# This gives us a modified "releases: [{...}, {...}]" segment of the final deployment manifest.
+# We now need to merge this back into the original manifest.
+#
+# But, I don't want to just use `spruce merge` for this as it will reorder the manifest and
+# make it ugly. If I didn't care about the manifest's aesthetics then this whole script
+# would be simpler. I want the original layout of the manifest to be retained; and so
+# we will just chomp out the original "releases:" section at the end of the file and
+# paste in the updated releases section.
+function bump_version {
+  manifest_path=$1
+  releases_updated=$(spruce merge <<YAML
+releases: $(spruce json "$manifest_path" | jq --arg name $NAME --arg version $VERSION --arg url $RELEASE_TGZ_URL --arg sha1 $RELEASE_TGZ_SHA1 --arg stemcell_os $STEMCELL_OS --arg stemcell_version $STEMCELL_VERSION '.releases | map(
+    if .name == $name
+    then . + {"version":$version,"url":$url,"sha1":$sha1,"stemcell":{"os":$stemcell_os,"version":$stemcell_version}}
+    else .
+    end)'
+)
+YAML
+)
+  releases_line_number=$(awk '/^releases:/{ print NR; exit }' $manifest_path)
+  manifest_head=$(head -n `expr $releases_line_number - 1` $manifest_path)
+  cat > $manifest_path <<YAML
+${manifest_head}
+
+${releases_updated}
+YAML
+}
+
+for manifest_path in $(ls $MANIFESTS_DIR/*.yml); do
+  if [[ $manifest_path == *-vars.yml ]]; then
+    continue
+  fi
+  bump_version $manifest_path
+done

--- a/ci/scripts/update-manifest-release
+++ b/ci/scripts/update-manifest-release
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# The goal of this script is to retain the pretty nature of manifests, whilst updating
+# the "releases:" section.
+#
+# If we use `spruce merge` to do the job, the entire manifest will be reordered -
+# keys will be sorted alphabetically. Comments will be lost.
+#
+# Instead, we assume that "releases:" is the last section of the manifest.
+set -e
+
+NAME=$1
+VERSION=$2
+RELEASE_TGZ_URL=$3
+RELEASE_TGZ_SHA1=$4
+if [[ "${RELEASE_TGZ_SHA1:-X}" == "X" ]]; then
+  echo "USAGE: update-manifest-release NAME VERSION URL SHA1"
+  exit 1
+fi
+: ${REPO_ROOT:?required}
+: ${REPO_OUT:?required}
+: ${MANIFESTS_DIR:?required}
+
+# So, this is a nested bash/spruce/jq combo.
+# What is happening here is that the "releases:" section of each deployment manifest
+# is being updated with the new version/sha1 for the release.
+#
+# We use "spruce json manifest.yml | jq '.releases'" to extract the existing releases array
+# and the '.releases | map(if .name == $name)' will modify a specific element of the array
+#
+# This gives us a modified "releases: [{...}, {...}]" segment of the final deployment manifest.
+# We now need to merge this back into the original manifest.
+#
+# But, I don't want to just use `spruce merge` for this as it will reorder the manifest and
+# make it ugly. If I didn't care about the manifest's aesthetics then this whole script
+# would be simpler. I want the original layout of the manifest to be retained; and so
+# we will just chomp out the original "releases:" section at the end of the file and
+# paste in the updated releases section.
+function bump_version {
+  manifest_path=$1
+  releases_updated=$(spruce merge <<YAML
+releases: $(spruce json "$manifest_path" | jq --arg name $NAME --arg version $VERSION --arg url $RELEASE_TGZ_URL --arg sha1 $RELEASE_TGZ_SHA1 '.releases | map(
+    if .name == $name
+    then . + {"version":$version,"url":$url,"sha1":$sha1}
+    else .
+    end)'
+)
+YAML
+)
+  releases_line_number=$(awk '/^releases:/{ print NR; exit }' $manifest_path)
+  manifest_head=$(head -n `expr $releases_line_number - 1` $manifest_path)
+  cat > $manifest_path <<YAML
+${manifest_head}
+
+${releases_updated}
+YAML
+}
+
+for manifest_path in $(ls $MANIFESTS_DIR/*.yml); do
+  if [[ $manifest_path == *-vars.yml ]]; then
+    continue
+  fi
+  bump_version $manifest_path
+done

--- a/ci/scripts/use-compiled-releases
+++ b/ci/scripts/use-compiled-releases
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -eu
+
+git clone ${REPO_ROOT} ${REPO_OUT}
+
+if [[ -z $(git config --global user.email) ]]; then
+  git config --global user.email "${GIT_EMAIL}"
+fi
+if [[ -z $(git config --global user.name) ]]; then
+  git config --global user.name "${GIT_NAME}"
+fi
+
+STEMCELL_OS=${STEMCELL_OS:-ubuntu-xenial}
+STEMCELL_VERSION=$(cat stemcell/version)
+
+releases=($(ls -d *compiled-release))
+
+for release in "${releases[@]}"; do
+
+  tar -xzf $release/*.tgz $( tar -tzf $release/*.tgz | grep 'release.MF' )
+  release_name=$( grep -E '^name: ' release.MF | awk '{print $2}' | tr -d "\"'" )
+  release_version=$( grep -E '^version: ' release.MF | awk '{print $2}' | tr -d "\"'" )
+  release_url=$(cat $release/url)
+  release_sha1=$(sha1sum $release/*.tgz | awk '{print $1}')
+
+  pushd ${REPO_OUT}
+    ci/scripts/update-manifest-compiled-release $release_name $release_version $release_url $release_sha1 $STEMCELL_OS $STEMCELL_VERSION
+  popd
+done
+
+pushd ${REPO_OUT}
+  git merge --no-edit ${BRANCH}
+  git add -A
+  git status
+  git commit -m "Updated compiled releases for ${STEMCELL_OS}/${STEMCELL_VERSION}"
+popd

--- a/ci/scripts/wait-until-proxy-bosh-cf-running
+++ b/ci/scripts/wait-until-proxy-bosh-cf-running
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -eu
+
+header() {
+	echo
+	echo "###############################################"
+	echo
+	echo $*
+	echo
+}
+
+if [[ "${PROXY_IP:-X}" != "X" ]]; then
+  : ${PROXY_USERNAME:?required if PROXY_IP set}
+  : ${PROXY_PRIVATE_KEY:?required if PROXY_IP set}
+  ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../.." && pwd )"
+  cd $ROOT
+
+  mkdir -p proxy/ssh
+  chmod 700 proxy/ssh
+  echo "${PROXY_PRIVATE_KEY}" > proxy/ssh/private_key
+  chmod 600 proxy/ssh/private_key
+
+  header "Checking jumpbox available..."
+  set +e
+  until ssh ${PROXY_USERNAME}@${PROXY_IP} -i proxy/ssh/private_key \
+      -o BatchMode=yes -o StrictHostKeyChecking=no -o ConnectTimeout=60 \
+      "whoami"
+  do
+    echo "Waiting until jumpbox/proxy available..."
+  done
+  set -e
+
+  header "Starting socks5 proxy..."
+  ssh ${PROXY_USERNAME}@${PROXY_IP} -i proxy/ssh/private_key -N -D 9999 &
+  sleep 10
+
+  echo BOSH_ALL_PROXY=socks5://localhost:9999
+  export BOSH_ALL_PROXY=socks5://localhost:9999
+fi
+
+header "Checking bosh available..."
+until bosh env; do
+  echo "Waiting until bosh available..."
+	sleep 60
+done
+
+if [[ -f git/tmp/vars.yml ]]; then
+	cf_api_url=$(bosh int git/tmp/vars.yml --path /cf-api-url)
+	if [[ "${cf_api_url:-X}" != "X" ]]; then
+		header "Checking Cloud Foundry available..."
+		until cf api $cf_api_url --skip-ssl-validation; do
+		  echo "Waiting until Cloud Foundry available..."
+		  sleep 60
+		done
+	fi
+fi
+
+echo
+echo

--- a/ci/settings.yml
+++ b/ci/settings.yml
@@ -1,0 +1,105 @@
+---
+meta:
+  name:     uaa
+  target:   gk-plat-devs
+  url:      https://ci.gstack.io
+  team:     gk-plat-devs
+  pipeline: (( concat "gk-" meta.name "-boshrelease" ))
+
+  test-errands: ~
+
+  initial_version: 74.29.1
+
+  manifest:
+    directory: manifests
+
+  git:
+    email:  ((git-commit-email))
+    name:   ((git-commit-name))
+
+  image:
+    name: gstack/gk-ops
+  ruby-image:
+    name: ruby
+    tag:  2.3.7-slim
+
+  aws:
+    bucket:      (( grab meta.pipeline ))
+    region_name: eu-west-3
+    access_key:  ((aws-access-key))
+    secret_key:  ((aws-secret-key))
+
+  github:
+    owner:  gstackio
+    repo:   (( grab meta.pipeline ))
+    branch: feature/github-oauth2
+
+    private_key:  ((github-private-key))
+    access_token: ((github-access-token))
+
+  bosh:
+    stemcell:
+      cpi: "warden-boshlite"
+
+  slack:
+    webhook:       ((slack-webhook))
+    username:      ((slack-username))
+    icon:          ((slack-icon-url))
+    channel:       gstack-engineering
+    blob_success:  '(( concat ": New version of  was detected, and updated in master. <" meta.url "/teams//pipelines/| Cut a new release?>" ))'
+    blob_failure:  '(( concat ": :airplane_arriving: <" meta.url "/teams//pipelines//jobs//builds/| Failed to update the blob for >" ))'
+
+
+
+groups:
+  - name: (( grab meta.pipeline ))
+    jobs:
+      - (( prepend ))
+      - pre-flight
+
+jobs:
+  - name: pre-flight
+    public: true
+    serial: true
+    plan:
+    - name: main
+      do:
+      - { get: git, trigger: true }
+      - { get: ruby-image }
+      - name: pre-flight
+        task: pre-flight
+        image: ruby-image
+        config:
+          platform: linux
+          inputs:
+            - { name: git }
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -ueo pipefail
+                pushd "git" > /dev/null
+                bundle install
+                rake
+      on_failure:
+        put: notify
+        params:
+          channel:  (( grab meta.slack.channel ))
+          username: (( grab meta.slack.username ))
+          icon_url: (( grab meta.slack.icon ))
+          text:    '(( concat meta.slack.fail_url " " meta.pipeline ": testflight job failed" ))'
+
+  - name: testflight
+    plan:
+    - name: main
+      do:
+      - (( inline ))
+      - { get: git, trigger: true, passed: [ pre-flight ] }
+
+resources:
+  - name: ruby-image
+    type: docker-image
+    source:
+      repository: (( grab meta.ruby-image.name ))
+      tag:        (( grab meta.ruby-image.tag ))

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+RELEASE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+pushd "${RELEASE_DIR}" > /dev/null
+
+team="$(    bosh int ci/settings.yml --path /meta/team)"
+pipeline="$(bosh int ci/settings.yml --path /meta/pipeline)"
+
+credhub set -n "/concourse/${team}/git-commit-email"    -t value -v "$(bosh int ci/secrets.yml --path /git_user_email)"
+credhub set -n "/concourse/${team}/git-commit-name"     -t value -v "$(bosh int ci/config.yml  --path /git_user_name)"
+credhub set -n "/concourse/${team}/aws-access-key"      -t value -v "$(bosh int ci/secrets.yml --path /s3_access_key_id)"
+credhub set -n "/concourse/${team}/aws-secret-key"      -t value -v "$(bosh int ci/secrets.yml --path /s3_secret_access_key)"
+
+credhub set -n "/concourse/${team}/slack-username"            -t value -v "gk-concourse-ninja"
+credhub set -n "/concourse/${team}/slack-icon-url"            -t value -v "https://cl.ly/2F421Y300u07/concourse-logo-blue-transparent.png"
+credhub set -n "/concourse/${team}/${pipeline}/slack-webhook" -t value -v "$(bosh int ci/secrets.yml --path /slack_webhook)"
+
+credhub set -n "/concourse/${team}/github-access-token" -t value -v "$(bosh int ci/secrets.yml --path /github_access_token)"
+credhub set -n "/concourse/${team}/github-private-key"  -t value -v "$(bosh int ci/secrets.yml --path /github_private_key)"
+
+credhub set -n "/concourse/${team}/bosh-lite-environment"   -t value -v "$(bosh int ci/secrets.yml --path /bosh-lite-environment)"
+credhub set -n "/concourse/${team}/bosh-lite-ca-cert"       -t value -v "$(bosh int ci/secrets.yml --path /bosh-lite-ca-cert)"
+credhub set -n "/concourse/${team}/bosh-lite-client"        -t value -v "$(bosh int ci/secrets.yml --path /bosh-lite-client)"
+credhub set -n "/concourse/${team}/bosh-lite-client-secret" -t value -v "$(bosh int ci/secrets.yml --path /bosh-lite-client-secret)"
+
+# To delete all:
+#
+#     credhub find | awk '/concourse/{print $3}' | xargs -n 1 credhub delete -n
+# or
+#     credhub find --path "/concourse/main" --output-json | jq -r ".credentials[].name" | xargs -n 1 credhub delete -n
+
+popd > /dev/null


### PR DESCRIPTION
Hi Cloud Foundry fellows,

I've implemented support for Github OAuth 2 as Identity Provider (IdP). This fixes the issue described in #798.

All 4600+ tests are passing. (I didn't fork from the latests `develop` HEAD because tests are currently not passing there.)
I've added some unit tests to cover the main Github use-case OAuth 2.0 “Autorization Code Grant” flow.
There is also some documentation showing how to use it.
I've deployed this version of UAA in a Cloud Foundry, making a fork of the `uaa-release`. Testing the result my own Gstack's sandbox CF environment, the real-life Github authentication works fine.

As a design choice that could be discussed, I've re-used the `checkTokenUrl` property (that is not used anywhere), in order to implement the “user-info” endpoint.

Best,
Benjamin
