### PR TITLE
fix: missing information about the CA certificates

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -92,6 +92,9 @@ properties:
       enabled_skip_hostname_validation (use TLS but skip validation of common and alt names in the host certificate),
       enabled_skip_all_validation (use TLS but do not validate anything about the host certificate),
       disabled (do not use TLS)
+
+      The database's CA certificate required when TLS is enabled
+      should be added to the uaa.ca_certs configuration field.
     default: enabled
   uaadb.tls_protocols:
     description: |


### PR DESCRIPTION
* it was unclear where to add the database's CA certificate in the
  configuration.

Someone was [having trouble](https://cloudfoundry.slack.com/archives/C03FXANBV/p1613705823043700?thread_ts=1613115829.037100&cid=C03FXANBV) finding how to configure the DB's CA certificates. 

This [code](https://github.com/pivotal-cf/p-runtime/blob/35d8e0120c17d2bfbcf60c688f42c79230444ce7/jobs/uaa.yml#L54) seems to prove to me that this is indeed the field which should take the CA certificates in. 

This [commit](https://github.com/pivotal-cf/p-runtime/commit/9954670b0013b235e55952bab173c8c558eca7f5#diff-1db3fe9ed61dbaed3d9ce108736d0b37285ccf7ea7c873148a370a463936530aR52) also seems to prove it.