### PR TITLE
Allow to set database.testwhileidle

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -832,6 +832,9 @@ properties:
     default: true
   uaa.database.case_insensitive:
     description: "Set to true if you don't want to be using LOWER() SQL functions in search queries/filters, because you know that your DB is case insensitive. If this property is null, then it will be set to true if the UAA DB is MySQL and false otherwise, but even on MySQL you can override it by setting it explicitly to false"
+  uaa.database.test_while_idle:
+    description: "If true connections will be validated by the idle connection evictor (if any). If the validation fails, the connection is destroyed and removed from the pool."
+    default: false
 
   # LDAP
   uaa.ldap.enabled:

--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -750,7 +750,7 @@ properties:
 
   # Scim properties
   uaa.scim.user.override:
-    description: "If true override users defined in uaa.scim.users found in the database."
+    description: "If true, override users defined in uaa.scim.users found in the database."
     default: true
   uaa.scim.userids_enabled:
     description: "Enables the endpoint `/ids/Users` that allows consumers to translate user ids to name"
@@ -833,7 +833,7 @@ properties:
   uaa.database.case_insensitive:
     description: "Set to true if you don't want to be using LOWER() SQL functions in search queries/filters, because you know that your DB is case insensitive. If this property is null, then it will be set to true if the UAA DB is MySQL and false otherwise, but even on MySQL you can override it by setting it explicitly to false"
   uaa.database.test_while_idle:
-    description: "If true connections will be validated by the idle connection evictor (if any). If the validation fails, the connection is destroyed and removed from the pool."
+    description: "If true, connections will be validated by the idle connection evictor (if any). If the validation fails, the connection is destroyed and removed from the pool."
     default: false
 
   # LDAP

--- a/jobs/uaa/templates/config/uaa.yml.erb
+++ b/jobs/uaa/templates/config/uaa.yml.erb
@@ -183,7 +183,8 @@
       'minidle' => p('uaa.database.min_idle_connections'),
       'removeabandoned' => p('uaa.database.remove_abandoned'),
       'logabandoned' =>  p('uaa.database.log_abandoned'),
-      'abandonedtimeout' => p('uaa.database.abandoned_timeout')
+      'abandonedtimeout' => p('uaa.database.abandoned_timeout'),
+      'testwhileidle' => p('uaa.database.test_while_idle')
     },
     'authentication' => {
       'enableUriEncodingCompatibilityMode' => p('uaa.authentication.enable_uri_encoding_compatibility_mode'),

--- a/spec/compare/all-properties-set-uaa.yml
+++ b/spec/compare/all-properties-set-uaa.yml
@@ -23,6 +23,7 @@ database:
   logabandoned: false
   abandonedtimeout: 301
   caseinsensitive: true
+  testwhileidle: true
 
 delete:
   clients:

--- a/spec/compare/bosh-lite-uaa.yml
+++ b/spec/compare/bosh-lite-uaa.yml
@@ -17,6 +17,7 @@ database:
   removeabandoned: false
   logabandoned: true
   abandonedtimeout: 300
+  testwhileidle: false
 
 
 spring_profiles: postgresql

--- a/spec/compare/deprecated-properties-still-work-uaa.yml
+++ b/spec/compare/deprecated-properties-still-work-uaa.yml
@@ -22,6 +22,7 @@ database:
   removeabandoned: false
   logabandoned: true
   abandonedtimeout: 300
+  testwhileidle: false
 authentication:
   enableUriEncodingCompatibilityMode: false
   policy:

--- a/spec/compare/test-defaults-uaa.yml
+++ b/spec/compare/test-defaults-uaa.yml
@@ -22,6 +22,7 @@ database:
   removeabandoned: false
   logabandoned: true
   abandonedtimeout: 300
+  testwhileidle: false
 authentication:
   enableUriEncodingCompatibilityMode: false
   policy:

--- a/spec/input/all-properties-set.yml
+++ b/spec/input/all-properties-set.yml
@@ -447,6 +447,7 @@ properties:
       max_idle_connections: 11
       min_idle_connections: 1
       remove_abandoned: true
+      test_while_idle: true
     delete:
       clients:
         - client-to-be-deleted-1


### PR DESCRIPTION
With this PR the property database.testwhileidle can be set for the UAA via this bosh release.

It is already possible to configure this property in the UAA via uaa.yml, however it is not possible to configure it via bosh release. With this PR this is now possible. As the value defaults to false [in the UAA](https://github.com/cloudfoundry/uaa/blob/develop/server/src/main/resources/spring/data-source.xml#L25), also here the default value will be false (-> no change in the current behavior)