### PR TITLE
Allow to configure additional parameters for db connection string

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -841,6 +841,11 @@ properties:
   uaa.database.test_while_idle:
     description: "If true, connections will be validated by the idle connection evictor (if any). If the validation fails, the connection is destroyed and removed from the pool."
     default: false
+  uaa.database.additionalParameters:
+    description: "Addtional parameters that should be added to the url that is used to connect to the database. Boolean values need to be passed as String."
+    example:
+      tcpKeepAlive: "true"
+      usePipelineAuth: "false"
 
   # LDAP
   uaa.ldap.enabled:

--- a/jobs/uaa/templates/config/uaa.yml.erb
+++ b/jobs/uaa/templates/config/uaa.yml.erb
@@ -269,6 +269,16 @@
     end
   end
 
+ if_p('uaa.database.additionalParameters') do |dbParameters|
+   paramString = ''
+   dbParameters.each do |key, value|
+     next unless value
+     # ? for first parameter already included in ssl parameter
+     paramString += '&' + key + '=' + value
+   end
+   params['database']['url'] += paramString
+ end
+
   # should the DB not use lower() function in SCIM queries (if true)
   if_p('uaa.database.case_insensitive') do |case_insensitive|
     params['database']['caseinsensitive'] = case_insensitive

--- a/spec/compare/all-properties-set-uaa.yml
+++ b/spec/compare/all-properties-set-uaa.yml
@@ -13,7 +13,7 @@ spring_profiles: mysql,ldap
 logging:
   config: "/var/vcap/jobs/uaa/config/log4j2.properties"
 database:
-  url: jdbc:mysql://10.244.0.30:5524/uaadb?useSSL=true&enabledSslProtocolSuites=TLSv1.2
+  url: jdbc:mysql://10.244.0.30:5524/uaadb?useSSL=true&enabledSslProtocolSuites=TLSv1.2&tcpKeepAlive=true&usePipelineAuth=false
   username: uaaadmin
   password: admin
   maxactive: 101

--- a/spec/input/all-properties-set.yml
+++ b/spec/input/all-properties-set.yml
@@ -450,6 +450,9 @@ properties:
       min_idle_connections: 1
       remove_abandoned: true
       test_while_idle: true
+      additionalParameters:
+        tcpKeepAlive: "true"
+        usePipelineAuth: "false"
     delete:
       clients:
         - client-to-be-deleted-1


### PR DESCRIPTION
We recently had a requirement very similar to #230 where we wanted to add an additional parameter to the connection URL for the database generated by the release.

With this change a new section "additionalParameters" is introduced to the database section of the input file. All of the entries in this section are taken as key value pairs and added as parameters to the generated URL.

The examples here are the values that are requested in #230 and what we need for our scenario - but basically it will work any pair of key/value and just add it to the URL.