### PR TITLE
Upgrade Bellsoft JDK to version 11.0.12+7

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-bellsoft-11.0.11+9.tar.gz:
-  size: 207159115
-  object_id: a92ac6b0-1424-4f85-7661-b2ecc22c4439
-  sha: sha256:b5926f749a58f7b4dbde2bd0c3df008bb4adf3f6de23fdfe6774ab3a25f3d79c
+bellsoft-11.0.12+7.tar.gz:
+  size: 207346392
+  object_id: c4df91c0-3fca-4136-68be-2d3f0020a425
+  sha: sha256:7c38cbdd9f723ea3c4d1d99b5ad12ef84c7c4716898ed58e5b8a201d91c7fd97
 uaa/apache-tomcat-9.0.50.tar.gz:
   size: 11507318
   object_id: 2ba031d7-15b3-4307-5e81-c6c5caaa4c25


### PR DESCRIPTION
manually update, after bellsoft fixed sha1 output