### PR TITLE
fix: pre-start script failure due to `update-ca-certificates` race

### DIFF
--- a/jobs/uaa/templates/bin/pre-start.erb
+++ b/jobs/uaa/templates/bin/pre-start.erb
@@ -43,9 +43,18 @@ function build_new_cache_files {
     source /etc/os-release
     case "${ID}" in
       *ubuntu*)
-        # --certbundle is an undocumented flag in the update-ca-certificates script
-        # https://salsa.debian.org/debian/ca-certificates/blob/master/sbin/update-ca-certificates#L53
-        timeout --signal=KILL 180s /usr/sbin/update-ca-certificates -f -v --certbundle "$(basename "${OS_CERTS_FILE}")"
+        retry_count=0
+        max_retry_count=3
+
+        set +e
+        until [ $retry_count -ge $max_retry_count ]; do
+            # --certbundle is an undocumented flag in the update-ca-certificates script
+            # https://salsa.debian.org/debian/ca-certificates/blob/master/sbin/update-ca-certificates#L53
+            timeout --signal=KILL 180s /usr/sbin/update-ca-certificates -f -v --certbundle "$(basename "${OS_CERTS_FILE}")" && break
+            retry_count=$((retry_count + 1))
+            sleep 5
+        done
+        set -e
       ;;
 
       *suse|sles*)


### PR DESCRIPTION
condition

- Occasionally, the `update-ca-certificates` command would fail due
to another entity also performing `update-ca-certificates`, resulting
in an error like this during pre-start:
```
rehash: Can’t symlink D-TRUST_Root_Class_3_CA_2_EV_2009.pem, File exists
```
- This issue most recently manifests itself when UAA is used with
BOSH director with Ubuntu Jammy stemcell, where os-conf's `ca_cert`
job performs `update-ca-certificates` as well, resulting in a race
condition.
- This commit makes the pre-start more robust by adding retry logic
to `update-ca-certificates` command, which is modelled after os-conf's
own retry logic around the same command. See: https://github.com/cloudfoundry/os-conf-release/blob/9144afcd849b1b9400026bbe9d8455f7643130ce/jobs/ca_certs/templates/pre-start.sh.erb#L19-L35

[#182763642]
[Addresses https://github.com/cloudfoundry/uaa-release/issues/327]