### PR TITLE
Fix openssl pkcs12 export in pre-start.erb when in FIPS mode

### DIFF
--- a/jobs/uaa/templates/bin/pre-start.erb
+++ b/jobs/uaa/templates/bin/pre-start.erb
@@ -131,9 +131,16 @@ function process_certs {
 }
 
 function insert_ssl_cert {
+    local FIPS_OPTS=""
+    if [ -f "/proc/sys/crypto/fips_enabled" ]; then
+        local FIPS_ENABLED="$(cat /proc/sys/crypto/fips_enabled)"
+        if [ "${FIPS_ENABLED}" = 1 ]; then
+            FIPS_OPTS="-certpbe PBE-SHA1-3DES"
+        fi
+    fi
     log "Installing Server SSL certificate"
 
-    openssl pkcs12 -export -name uaa_ssl_cert \
+    openssl pkcs12 -export ${FIPS_OPTS} -name uaa_ssl_cert \
         -in /var/vcap/jobs/uaa/config/uaa.crt \
         -out /var/vcap/data/uaa/uaa_keystore.p12 \
         -password pass:k0*l*s3cur1tyr0ck$


### PR DESCRIPTION
On a Ubuntu Bionic FIPS enabled stemcell, pre-start.erb fails. In FIPS Mode, the PKCS#12 format must use compatible encryption and hashing algorithms.

Fixes: #358