### PR TITLE
Log tracing

### DIFF
--- a/jobs/uaa/templates/config/log4j2.properties.erb
+++ b/jobs/uaa/templates/config/log4j2.properties.erb
@@ -15,7 +15,7 @@ case logging_format_timestamp_value
 end
 %>
 property.log_directory = /var/vcap/sys/log/uaa
-property.log_pattern=[<%= timestamp_format %>] uaa%X{context} - %pid [%t] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=)([^&]*)}{<redacted>}%n
+property.log_pattern=[<%= timestamp_format %>] uaa%X{context} - %pid [%t] - [%X{traceId},%X{spanId}] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=)([^&]*)}{<redacted>}%n
 
 appender.uaaDefaultAppender.type = File
 appender.uaaDefaultAppender.name = UaaDefaultAppender

--- a/spec/compare/all-properties-set-log4j2.properties
+++ b/spec/compare/all-properties-set-log4j2.properties
@@ -3,7 +3,7 @@ dest = err
 name = UaaLog
 
 property.log_directory = /var/vcap/sys/log/uaa
-property.log_pattern=[%d{yyyy-MM-dd'T'HH:mm:ss.nnnnnn}{GMT+0}Z] uaa%X{context} - %pid [%t] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=)([^&]*)}{<redacted>}%n
+property.log_pattern=[%d{yyyy-MM-dd'T'HH:mm:ss.nnnnnn}{GMT+0}Z] uaa%X{context} - %pid [%t] - [%X{traceId},%X{spanId}] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=)([^&]*)}{<redacted>}%n
 
 appender.uaaDefaultAppender.type = File
 appender.uaaDefaultAppender.name = UaaDefaultAppender

--- a/spec/compare/default-log4j2-template.properties
+++ b/spec/compare/default-log4j2-template.properties
@@ -3,7 +3,7 @@ dest = err
 name = UaaLog
 
 property.log_directory = /var/vcap/sys/log/uaa
-property.log_pattern=[EXPECTED_LOG_PATTERN_PLACEHOLDER] uaa%X{context} - %pid [%t] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=)([^&]*)}{<redacted>}%n
+property.log_pattern=[EXPECTED_LOG_PATTERN_PLACEHOLDER] uaa%X{context} - %pid [%t] - [%X{traceId},%X{spanId}] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=)([^&]*)}{<redacted>}%n
 
 appender.uaaDefaultAppender.type = File
 appender.uaaDefaultAppender.name = UaaDefaultAppender

--- a/spec/compare/default-log4j2.properties
+++ b/spec/compare/default-log4j2.properties
@@ -3,7 +3,7 @@ dest = err
 name = UaaLog
 
 property.log_directory = /var/vcap/sys/log/uaa
-property.log_pattern=[%d{yyyy-MM-dd'T'HH:mm:ss.nnnnnn}{GMT+0}Z] uaa%X{context} - %pid [%t] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=)([^&]*)}{<redacted>}%n
+property.log_pattern=[%d{yyyy-MM-dd'T'HH:mm:ss.nnnnnn}{GMT+0}Z] uaa%X{context} - %pid [%t] - [%X{traceId},%X{spanId}] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=)([^&]*)}{<redacted>}%n
 
 appender.uaaDefaultAppender.type = File
 appender.uaaDefaultAppender.name = UaaDefaultAppender

--- a/src/acceptance_tests/uaa-release_test.go
+++ b/src/acceptance_tests/uaa-release_test.go
@@ -18,6 +18,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 )
@@ -141,7 +142,10 @@ var _ = Describe("UaaRelease", func() {
 
 	logLineWithoutTimestampRegex := ` uaa.* - \d+ \[([^]]+)\] - \[[^]]+\] .... (DEBUG|\sINFO|\sWARN) --- .+: .+`
 
-	DescribeTable("UAA log format", func(uaaLogFormat string, optFiles ...string) {
+	DescribeTable("UAA log format", func(
+		uaaLogFormat string,
+		optFiles ...string,
+	) {
 		deployUAA(optFiles...)
 
 		logPath := scpUAALog()
@@ -291,7 +295,10 @@ func scpUaaAuditLog() string {
 	return localUAALogPath
 }
 
-func getFingerPrint(certdata []byte) (string, error) {
+func getFingerPrint(certdata []byte) (
+	string,
+	error,
+) {
 	var block *pem.Block
 	block, _ = pem.Decode(certdata)
 

--- a/src/acceptance_tests/uaa-release_test.go
+++ b/src/acceptance_tests/uaa-release_test.go
@@ -18,7 +18,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
-	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 )
@@ -140,7 +139,7 @@ var _ = Describe("UaaRelease", func() {
 
 	})
 
-	logLineWithoutTimestampRegex := ` uaa.* - \d+ \[([^]]+)\] .... (DEBUG|\sINFO|\sWARN) --- .+: .+`
+	logLineWithoutTimestampRegex := ` uaa.* - \d+ \[([^]]+)\] - \[[^]]+\] .... (DEBUG|\sINFO|\sWARN) --- .+: .+`
 
 	DescribeTable("UAA log format", func(uaaLogFormat string, optFiles ...string) {
 		deployUAA(optFiles...)


### PR DESCRIPTION
Log tracing - this changes the UAA log format used in a bosh uaa deployment to include a trace ID and span ID, and adjusts the tests to match.

This should be merged after https://github.com/cloudfoundry/uaa/pull/2446 in order for the tests to pass. See that PR for details about the feature.

[#185000950]