### PR TITLE
Add spec file example for "performRpInitiatedLogout"

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -1049,6 +1049,7 @@ properties:
         relyingPartySecret: <OAuth Client secret>
         skipSslValidation: false
         storeCustomAttributes: true
+        performRpInitiatedLogout: true
         attributeMappings:
           given_name: <Attribute holding given name in the OAuth if an ID Token is present or the access token has claims>
           family_name: <Attribute holding family name in the OAuth if an ID Token is present or the access token has claims>
@@ -1077,6 +1078,7 @@ properties:
         skipSslValidation: false
         storeCustomAttributes: true
         passwordGrantEnabled: false
+        performRpInitiatedLogout: true
         attributeMappings:
           given_name: <Attribute holding given name in the OIDC ID Token>
           family_name: <Attribute holding family name in the OIDC ID Token>

--- a/spec/compare/all-properties-set-uaa.yml
+++ b/spec/compare/all-properties-set-uaa.yml
@@ -650,6 +650,7 @@ login:
         skipSslValidation: false
         storeCustomAttributes: false
         passwordGrantEnabled: false
+        performRpInitiatedLogout: true
         prompts:
           - name: username
             type: text

--- a/spec/input/all-properties-set.yml
+++ b/spec/input/all-properties-set.yml
@@ -107,6 +107,7 @@ properties:
           tokenKeyUrl: http://tokenKeyUrl
           tokenUrl: http://tokenUrl
           passwordGrantEnabled: false
+          performRpInitiatedLogout: true
           prompts:
             - name: username
               type: text


### PR DESCRIPTION
- a new oidc/oauth provider config "performRpInitiatedLogout" is added in https://github.com/cloudfoundry/uaa/pull/2590
- this repo only requires an addition in the example config provided in the spec file (since uaa-release passes through the oauth/oidc provider config to uaa server verbatim, so no new translation logic required when adding a new config on this layer)
- add the field to tests
- This PR fixes https://github.com/cloudfoundry/uaa-release/issues/701