### PR TITLE
Fix pre-start.erb for Jammy FIPS stemcell

### DIFF
--- a/jobs/uaa/templates/bin/pre-start.erb
+++ b/jobs/uaa/templates/bin/pre-start.erb
@@ -135,7 +135,7 @@ function insert_ssl_cert {
     if [ -f "/proc/sys/crypto/fips_enabled" ]; then
         local FIPS_ENABLED="$(cat /proc/sys/crypto/fips_enabled)"
         if [ "${FIPS_ENABLED}" = 1 ]; then
-            FIPS_OPTS="-certpbe PBE-SHA1-3DES"
+            FIPS_OPTS="-nomac"
             log "Detect FIPS enabled"
         fi
     fi


### PR DESCRIPTION
Fix for https://github.com/cloudfoundry/uaa-release/issues/722

* algorithm "PBE-SHA1-3DES" is not available on FIPS Jammy (OpenSSL 3.0.2 / Ubuntu 22.04.3 LTS)
* so use the "-nomac" option instead as recommended on https://www.openssl.org/docs/man3.0/man1/openssl-pkcs12.html#NOTES