### PR TITLE
Revert "Bump github.com/cloudfoundry/bosh-utils in /src/acceptance tests (#785)"

### DIFF
--- a/src/acceptance_tests/go.mod
+++ b/src/acceptance_tests/go.mod
@@ -4,7 +4,7 @@ go 1.21.5
 
 require (
 	github.com/cloudfoundry/bosh-cli v6.4.1+incompatible
-	github.com/cloudfoundry/bosh-utils v0.0.430
+	github.com/cloudfoundry/bosh-utils v0.0.428
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.31.1
 )

--- a/src/acceptance_tests/go.sum
+++ b/src/acceptance_tests/go.sum
@@ -10,8 +10,8 @@ github.com/charlievieth/fs v0.0.3 h1:3lZQXTj4PbE81CVPwALSn+JoyCNXkZgORHN6h2XHGlg
 github.com/charlievieth/fs v0.0.3/go.mod h1:hD4sRzto1Hw8zCua76tNVKZxaeZZr1RiKftjAJQRLLo=
 github.com/cloudfoundry/bosh-cli v6.4.1+incompatible h1:n5/+NIF9QxvGINOrjh6DmO+GTen78MoCj5+LU9L8bR4=
 github.com/cloudfoundry/bosh-cli v6.4.1+incompatible/go.mod h1:rzIB+e1sn7wQL/TJ54bl/FemPKRhXby5BIMS3tLuWFM=
-github.com/cloudfoundry/bosh-utils v0.0.430 h1:JmpeUUZ3+stnsFjw1ltnwRvtJjLqtSfeeNmusJsh304=
-github.com/cloudfoundry/bosh-utils v0.0.430/go.mod h1:E2xXX9IdpuJP19j102Mb0vyYj8WtCdBWdT3lF11gxFk=
+github.com/cloudfoundry/bosh-utils v0.0.428 h1:ltEpafi1mWG1htQTfCjDKk3vE0qcSEKVx1FyfpFmw0E=
+github.com/cloudfoundry/bosh-utils v0.0.428/go.mod h1:E2xXX9IdpuJP19j102Mb0vyYj8WtCdBWdT3lF11gxFk=
 github.com/cloudfoundry/go-socks5 v0.0.0-20180221174514-54f73bdb8a8e h1:FQdRViaoDphGRfgrotl2QGsX1gbloe57dbGBS5CG6KY=
 github.com/cloudfoundry/go-socks5 v0.0.0-20180221174514-54f73bdb8a8e/go.mod h1:PXmcacyJB/pJjSxEl15IU6rEIKXrhZQRzsr0UTkgNNs=
 github.com/cloudfoundry/socks5-proxy v0.2.108 h1:YlCS+j0Xgatwq5Kux2idwwzHmRZBheZD2nynEf4Jdr0=


### PR DESCRIPTION
* This reverts commit d04778d06be912bbcc36a580c11ab0a3a3a388b9.
* Trying to fix a CI failure in uaa-acceptance-gcp / test-cf-deployment-integration that started after this bump.