### PR TITLE
remove: gomega github ignore removed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,9 +34,3 @@ updates:
     time: "11:00"
   target-branch: "74.5.x"
   open-pull-requests-limit: 10
-  ignore:
-    - dependency-name: "github.com/onsi/gomega"
-    # gomega 1.31 requires go 1.20. However, legacy-bosh-docker-image
-    # we use for in uaa-ci/concourse/v74-5-x-lts/pipeline.yml has go 1.19.
-    # Can be bumped only after we change the legacy-bosh-docker-image
-    # there.


### PR DESCRIPTION
Ignore for gomega has been removed since the go restriction has been resolved by removing docker image using older version of go.

[#186986896]