### PR TITLE
Revert "remove: gomega github ignore removed"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,9 @@ updates:
     time: "11:00"
   target-branch: "74.5.x"
   open-pull-requests-limit: 10
+  ignore:
+    - dependency-name: "github.com/onsi/gomega"
+    # gomega 1.31 requires go 1.20. However, legacy-bosh-docker-image
+    # we use for in uaa-ci/concourse/v74-5-x-lts/pipeline.yml has go 1.19.
+    # Can be bumped only after we change the legacy-bosh-docker-image
+    # there.


### PR DESCRIPTION
Reverts cloudfoundry/uaa-release#796

The docker image used in the uaa-release-test is deprecated but has go.1.19.4 which gomega is incompatible with. It requires Go 1.20 ( likely or newer ) 

The bosh/integration image (https://hub.docker.com/r/bosh/integration) recommended by the deprecated bosh/main-bosh-docker (https://hub.docker.com/r/bosh/main/#! ) image does not start bosh when swapped and further work is needed to implement a newer image. 

```
# github.com/onsi/gomega/internal
../../pkg/mod/github.com/onsi/gomega@v1.31.1/internal/async_assertion.go:556:19: undefined: context.Cause
note: module requires Go 1.20
```