### PR TITLE
doc: clarify use of multiple URLs in uaa.ldap.url

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -893,7 +893,7 @@ properties:
     description: "The file to be used for configuring the LDAP authentication. Options are: 'simple-bind', 'search-and-bind', 'search-and-compare'"
     default: search-and-bind
   uaa.ldap.url:
-    description: "The URL to the ldap server, must start with ldap:// or ldaps://. Allows multiple servers to be specified, space separated"
+    description: "The URL to the ldap server, must start with ldap:// or ldaps://. Allows multiple server URLs to be specified for failover purpose, space separated."
     example: ldap://localhost:389 ldaps://secure.host:636
   uaa.ldap.userDNPattern:
     description: "Used with simple-bind only. A semi-colon separated lists of DN patterns to construct a DN direct from the user ID without performing a search."


### PR DESCRIPTION
- clarify that the option to put multiple URLs in uaa.ldap.url is for failover purpose only (the
URLs beyond the first one are the backups if
the first URL fails).
- The previous language could mislead operators into thinking that multiple distinct LDAP servers
can be configured at the same time via uaa.ldap.url.
- details: UAA [passes through](https://github.com/cloudfoundry/uaa/blob/05dc2c0d9903bece514fd1308f03c34792205faf/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/LdapSimpleBindConfig.java#L41) the configured value to spring-security-ldap library, which then [uses the extra URLs for failover purpose](https://github.com/spring-projects/spring-security/blob/48c8532a21d0aab17eac400ec3540b01249b5962/ldap/src/main/java/org/springframework/security/ldap/DefaultSpringSecurityContextSource.java#L60).

[#185846888]