### PR TITLE
Revert "remove: gomega github ignore removed"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,9 @@ updates:
     time: "11:00"
   target-branch: "74.5.x"
   open-pull-requests-limit: 10
+  ignore:
+    - dependency-name: "github.com/onsi/gomega"
+    # gomega 1.31 requires go 1.20. However, legacy-bosh-docker-image
+    # we use for in uaa-ci/concourse/v74-5-x-lts/pipeline.yml has go 1.19.
+    # Can be bumped only after we change the legacy-bosh-docker-image
+    # there.


### PR DESCRIPTION
- We still cannot bump gomega to 1.31.
- Previous commit to remove the bump-ignore should not have been made.

This reverts commit aa1f85673f2b6560bb79551380a7edaf1e48aa83.