### PR TITLE
Revert "Bump github.com/cloudfoundry/bosh-utils from 0.0.461 to 0.0.463 in /src/acceptance_tests"

### DIFF
--- a/src/acceptance_tests/go.mod
+++ b/src/acceptance_tests/go.mod
@@ -4,7 +4,7 @@ go 1.21.5
 
 require (
 	github.com/cloudfoundry/bosh-cli v6.4.1+incompatible
-	github.com/cloudfoundry/bosh-utils v0.0.463
+	github.com/cloudfoundry/bosh-utils v0.0.461
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.33.1
 )

--- a/src/acceptance_tests/go.sum
+++ b/src/acceptance_tests/go.sum
@@ -10,8 +10,8 @@ github.com/charlievieth/fs v0.0.3 h1:3lZQXTj4PbE81CVPwALSn+JoyCNXkZgORHN6h2XHGlg
 github.com/charlievieth/fs v0.0.3/go.mod h1:hD4sRzto1Hw8zCua76tNVKZxaeZZr1RiKftjAJQRLLo=
 github.com/cloudfoundry/bosh-cli v6.4.1+incompatible h1:n5/+NIF9QxvGINOrjh6DmO+GTen78MoCj5+LU9L8bR4=
 github.com/cloudfoundry/bosh-cli v6.4.1+incompatible/go.mod h1:rzIB+e1sn7wQL/TJ54bl/FemPKRhXby5BIMS3tLuWFM=
-github.com/cloudfoundry/bosh-utils v0.0.463 h1:shFYtlAAFEEsUnE1C9wsp9ICmB8mH3H/0WtagZSJtIM=
-github.com/cloudfoundry/bosh-utils v0.0.463/go.mod h1:F1VS6oF25yVUs54XnpmcmVQCJHyc+D06YJciBpsitZ4=
+github.com/cloudfoundry/bosh-utils v0.0.461 h1:OsJ+0kP2yd+jGYqJPpISc6/wLaxXJNejCG+DU+H0s8w=
+github.com/cloudfoundry/bosh-utils v0.0.461/go.mod h1:F1VS6oF25yVUs54XnpmcmVQCJHyc+D06YJciBpsitZ4=
 github.com/cloudfoundry/go-socks5 v0.0.0-20180221174514-54f73bdb8a8e h1:FQdRViaoDphGRfgrotl2QGsX1gbloe57dbGBS5CG6KY=
 github.com/cloudfoundry/go-socks5 v0.0.0-20180221174514-54f73bdb8a8e/go.mod h1:PXmcacyJB/pJjSxEl15IU6rEIKXrhZQRzsr0UTkgNNs=
 github.com/cloudfoundry/socks5-proxy v0.2.116 h1:1zm31wkXnOdL9pXbtFUTFc/viIYBjF2xjbCOi/bzyNA=


### PR DESCRIPTION
Reverts cloudfoundry/uaa-release#869