### PR TITLE
Add more configurations for Identity providers in UAA

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -1027,6 +1027,7 @@ properties:
         skipSslValidation: false
         storeCustomAttributes: true
         performRpInitiatedLogout: true
+        authMethod: client_secret_basic
         jwtClientAuthentication:
           kid: key-id
         attributeMappings:
@@ -1058,6 +1059,10 @@ properties:
         storeCustomAttributes: true
         passwordGrantEnabled: false
         performRpInitiatedLogout: true
+        pkce: true
+        authMethod: client_secret_basic
+        additionalAuthzParameters:
+          - token_format: jwt <Additional attributes to be added to authorization request>
         jwtClientAuthentication:
           kid: key-id
         attributeMappings:

--- a/spec/compare/all-properties-set-uaa.yml
+++ b/spec/compare/all-properties-set-uaa.yml
@@ -632,6 +632,10 @@ login:
           here
         tokenKeyUrl: http://tokenKeyUrl
         cacheJwks: true
+        pkce: true
+        authMethod: client_secret_basic
+        additionalAuthzParameters:
+          - token_format: jwt
         issuer: http://tokenUrl
         scopes:
         - openid

--- a/spec/input/all-properties-set.yml
+++ b/spec/input/all-properties-set.yml
@@ -101,6 +101,10 @@ properties:
           tokenKeyUrl: http://tokenKeyUrl
           tokenUrl: http://tokenUrl
           cacheJwks: true
+          pkce: true
+          authMethod: client_secret_basic
+          additionalAuthzParameters:
+            - token_format: jwt
           passwordGrantEnabled: false
           performRpInitiatedLogout: true
           prompts:


### PR DESCRIPTION
Add parameter because of documentation reason
The support in bosh is given already because all sub parameters are taken over from bosh config into uaa.yml