### PR TITLE
Revert "Bump minitest from 5.25.1 to 5.25.2"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
     logger (1.6.1)
     method_source (1.1.0)
     mini_portile2 (2.8.8)
-    minitest (5.25.2)
+    minitest (5.25.1)
     nokogiri (1.16.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)


### PR DESCRIPTION
Reverts cloudfoundry/uaa-release#983