### PR TITLE
Add support for Spring Boot 2.7 in uaa-release

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -17,6 +17,7 @@ templates:
   config/ldap.crt.erb: config/ldap.crt
   config/messages.properties.erb: config/messages.properties
   config/uaa.crt.erb: config/uaa.crt
+  config/boot/application.yml.erb: config/boot/application.yml
   config/tomcat/tomcat.logging.properties: config/tomcat/logging.properties
   config/tomcat/tomcat.server.xml.erb: config/tomcat/server.xml
   config/tomcat/tomcat.context.xml.erb: config/tomcat/context.xml
@@ -50,6 +51,12 @@ packages:
   - uaa
 
 properties:
+  runtime.tomcat.enabled:
+    description: |
+      Deprecated. Set to true to force UAA to run within a Apache Tomcat container.
+      Set to false, to use a Spring Boot runtime with an embedded Apache Tomcat container.
+      This property will be removed when Apache Tomcat as a runtime is removed.
+    default: false
   uaa.rate_limiter:
     config:
       loggingOption:

--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -56,7 +56,7 @@ properties:
       Deprecated. Set to true to force UAA to run within a Apache Tomcat container.
       Set to false, to use a Spring Boot runtime with an embedded Apache Tomcat container.
       This property will be removed when Apache Tomcat as a runtime is removed.
-    default: false
+    default: true
   uaa.rate_limiter:
     config:
       loggingOption:

--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -62,25 +62,25 @@ properties:
       loggingOption:
         description: "(optional) String (see Details)"
         example: AllCallsWithDetails
-      credentialID: 
+      credentialID:
         description: "(optional) String (see Details)"
         example: 'JWT:Claims+"email"\s*:\s*"(.*?)"'
-      limiterMappings.name: 
+      limiterMappings.name:
         description: "(required) String"
         example: Info
-      limiterMappings.withCallerRemoteAddressID: 
+      limiterMappings.withCallerRemoteAddressID:
         description: "(optional but) String - (see Window Type)"
         example: 1r/s
-      limiterMappings.withCallerCredentialsID: 
+      limiterMappings.withCallerCredentialsID:
         description: "(optional but) String - (see Window Type)"
         example: 1r/s
-      limiterMappings.withoutCallerID: 
+      limiterMappings.withoutCallerID:
         description: "(optional but) String - (see Window Type)"
         example: 1r/s
-      limiterMappings.global: 
+      limiterMappings.global:
         description: "(optional but) String - (see Window Type)"
         example: 1r/s
-      limiterMappings.pathSelectors: 
+      limiterMappings.pathSelectors:
         description: "(required non-empty) List of String(s) - (see Path Selector)"
         example: "equals:/info"
 

--- a/jobs/uaa/templates/bin/pre-start.erb
+++ b/jobs/uaa/templates/bin/pre-start.erb
@@ -160,6 +160,19 @@ function configure_tomcat {
     chown -R vcap:vcap /var/vcap/data/uaa/
 }
 
+function configure_spring_boot {
+    # When run with bpm, the vcap user does not have permissions to read
+    # files in the jobs and packages directories. Consequently, we move
+    # our spring boot installation into a directory where we have full permissions.
+    rm -rf /var/vcap/data/uaa/boot
+    mkdir -p /var/vcap/data/uaa
+    cp -a /var/vcap/packages/uaa/boot /var/vcap/data/uaa/
+    cp -a /var/vcap/jobs/uaa/config/boot/* /var/vcap/data/uaa/boot/
+    mkdir -p /var/vcap/data/uaa/boot/webapps
+    mkdir -p /var/vcap/data/uaa/boot/work
+    chown -R vcap:vcap /var/vcap/data/uaa/boot
+}
+
 log "Starting"
 
 TMP_DIR="$(mktemp -d)"
@@ -178,6 +191,8 @@ PERSISTENT_LDAP_CERTS_FILE=$PERSISTENT_CERTS_DIR/ldap-certs-cache.txt
 process_certs
 
 configure_tomcat
+
+configure_spring_boot
 
 rm -rf $TMP_DIR
 

--- a/jobs/uaa/templates/bin/uaa
+++ b/jobs/uaa/templates/bin/uaa
@@ -36,11 +36,35 @@ JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=${uaa_log_dir}"
 export PATH
 export JAVA_OPTS
 
-log "Calling Tomcat start up command"
-/var/vcap/packages/uaa/tomcat/bin/catalina.sh run &
-CATALINA_PID=$!
-log "uaa/tomcat started in background. Waiting for signals."
-wait "${CATALINA_PID}"
-EXIT_STATUS=$?
-log "uaa/tomcat job exiting"
-exit $EXIT_STATUS
+BOOT_RUN_LOCATION=/var/vcap/data/uaa/boot
+BOOT_OPTS="${JAVA_OPTS}"
+### TODO what is the difference between -Dlog4j.configurationFile and -Dlogging.config?
+BOOT_OPTS="${BOOT_OPTS} -Dlogging.config=/var/vcap/jobs/uaa/config/log4j2.properties"
+BOOT_OPTS="${BOOT_OPTS} -DSECRETS_DIR=/var/vcap/jobs/uaa/config"
+BOOT_OPTS="${BOOT_OPTS} -Dmetrics.perRequestMetrics=true"
+BOOT_OPTS="${BOOT_OPTS} -Dserver.servlet.context-path=/"
+BOOT_OPTS="${BOOT_OPTS} -Dstatsd.enabled=true"
+BOOT_OPTS="${BOOT_OPTS} <%= p("uaa.catalina_opts") %>"
+BOOT_FILE=${BOOT_RUN_LOCATION}/uaa-boot.war
+
+TOMCAT_ENABLED=<%= p("runtime.tomcat.enabled") %>
+if [[ "${TOMCAT_ENABLED}" == "true" ]]; then
+  log "Calling Tomcat start up command"
+  /var/vcap/packages/uaa/tomcat/bin/catalina.sh run &
+  CATALINA_PID=$!
+  log "uaa/tomcat started in background. Waiting for signals."
+  wait "${CATALINA_PID}"
+  EXIT_STATUS=$?
+  log "uaa/tomcat job exiting"
+  exit $EXIT_STATUS
+else
+  # location of application.yml
+  cd ${BOOT_RUN_LOCATION}
+  java ${BOOT_OPTS} -jar ${BOOT_FILE} &
+  BOOT_PID=$!
+  log "uaa/boot started in background. Waiting for signals."
+  wait "${BOOT_PID}"
+  EXIT_STATUS=$?
+  log "uaa/boot job exiting"
+  exit $EXIT_STATUS
+fi

--- a/jobs/uaa/templates/config/boot/application.yml.erb
+++ b/jobs/uaa/templates/config/boot/application.yml.erb
@@ -1,0 +1,76 @@
+<%
+default_internal_proxies = "10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}"
+
+def escape(str)
+  str.gsub(".","\\.").gsub(":","\\:")
+end
+
+internal_proxies = p('uaa.proxy_ips_regex')
+
+if_p('uaa.proxy.servers') do |proxyServers|
+  internal_proxies = proxyServers.map { |ip| escape(ip) }
+                                 .push(internal_proxies)
+                                 .join('|')
+end
+if_link('router') do |router|
+  internal_proxies = router.instances.map { |instance| escape(instance.address) }
+                                     .push(internal_proxies)
+                                     .join('|')
+end
+
+if internal_proxies.to_s.strip.length == 0
+    internal_proxies = default_internal_proxies
+end
+
+if p("uaa.localhost_http_port") < 1024 || p("uaa.localhost_http_port") > 65535
+    raise ArgumentError, "Invalid value (#{p("uaa.localhost_http_port")}) specified for uaa.localhost_http_port, please specify a valid port number in this range [1024-65535]"
+end
+
+if p("uaa.ssl.port") < 1024 || p("uaa.ssl.port") > 65535
+    raise ArgumentError, "Invalid value (#{p("uaa.ssl.port")}) specified for uaa.ssl.port, please specify a valid port number in this range [1024-65535]"
+end
+
+if p("uaa.ssl.port") == p("uaa.localhost_http_port")
+    raise ArgumentError, 'Please specify different values for uaa.ssl.port and uaa.localhost_http_port'
+end
+
+if p("uaa.keepalive_timeout") < -1
+    raise ArgumentError, "Invalid value (#{p("uaa.keepalive_timeout")}) specified for uaa.keepalive_timeout, please specify either a positive integer value or -1"
+end
+%>
+
+server:
+  http: ## TODO these are extension properties for an additional port
+    port: <%= p('uaa.localhost_http_port') %>
+    address: "127.0.0.1"
+    connection-timeout: 20000
+    keep-alive-timeout: <%= p('uaa.keepalive_timeout') %>
+    max-http-header-size: 14336
+    bind-on-init: true
+  port: <%= p('uaa.ssl.port') %>
+  max-http-header-size: 14336
+  tomcat:
+    basedir: "/var/vcap/data/uaa/boot/"
+    connection-timeout: 20000
+    keep-alive-timeout: <%= p('uaa.keepalive_timeout') %>
+    remoteip:
+      remote-ip-header: "x-forwarded-for"
+      protocol-header: "<%= p('uaa.ssl.protocol_header') %>"
+      internal-proxies: <%= internal_proxies.gsub("\\","\\\\") %>
+      port-header: "<%= p('uaa.ssl.port_header') %>"
+    accesslog:
+      enabled: true
+      directory: "/var/vcap/sys/log/uaa"
+      prefix: "localhost_access"
+      suffix: ".log"
+      rotate: false
+      pattern: "%h %l %u %t &quot;%m %U %H&quot; %s %{Content-Length}i %b &quot;X-Vcap-Request-Id: %{X-Vcap-Request-Id}i&quot; %I"
+  ssl:
+    enabled: true
+    enabled-protocols: "<%= p('uaa.ssl.enabled_protocols') %>"
+    ciphers: "<%= p('uaa.ssl.ciphers') %>"
+    protocol: TLS
+    key-store: "/var/vcap/data/uaa/uaa_keystore.p12"
+    key-store-type: "PKCS12"
+    key-alias: "uaa_ssl_cert"
+    key-store-password: "k0*l*s3cur1tyr0ck$"

--- a/packages/uaa/packaging
+++ b/packages/uaa/packaging
@@ -30,3 +30,8 @@ cp -a "${BOSH_COMPILE_TARGET}"/wars/tomcat-listener.jar lib/tomcat-listener.jar
 
 chmod 0755 bin/
 chmod 0755 bin/*.sh
+
+# setup a spring boot directory
+cd ${BOSH_INSTALL_TARGET}
+mkdir boot
+cp -a "${BOSH_COMPILE_TARGET}"/wars/cloudfoundry-identity-uaa.war boot/uaa-boot.war

--- a/scripts/run-template-tests.rb
+++ b/scripts/run-template-tests.rb
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 
-# Failed with 3.0.3, not sure why
-if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('3.0.2')
-  puts "********\n******** WARNING: Ruby template tests might not be compatible with Ruby version > 3.0.2\n********"
+# Works with 3.4.4, require as minimum
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.4.4')
+  puts "********\n******** WARNING: Ruby template works well with Ruby version = 3.4.4, please upgrade.\n********"
 end
 Dir.chdir "#{__dir__}/.."
 system "gem install bundle"

--- a/spec/boot.application.yml.erb_spec.rb
+++ b/spec/boot.application.yml.erb_spec.rb
@@ -1,0 +1,245 @@
+require 'rspec'
+require 'yaml'
+require 'bosh/template/evaluation_context'
+require 'json'
+require 'support/yaml_eq'
+require 'spec_helper'
+
+describe 'boot.application.yml' do
+  def perform_erb_transformation_as_string(erb_file, manifest_file)
+      binding = Bosh::Template::EvaluationContext.new(manifest_file, nil).get_binding
+      ERB.new(erb_file).result(binding)
+  end
+
+  def perform_erb_transformation_as_yaml(erb_file, manifest_file)
+    YAML.load(
+        perform_erb_transformation_as_string(erb_file, manifest_file)
+    )
+  end
+
+  def perform_erb_transformation_as_string_doc_mode(erb_file)
+    require_relative '../docs/doc_overrides'
+    the_binding = Proc.new do
+      doc = 'true'
+      binding()
+    end.call
+    ERB.new(erb_file).result(the_binding)
+  end
+
+  def read_and_parse_string_template(template, manifest, asYaml, mode = :normal)
+    erbTemplate = File.read(File.join(File.dirname(__FILE__), template))
+
+    if mode == :doc
+      return perform_erb_transformation_as_string_doc_mode(erbTemplate)
+    end
+
+    if asYaml
+      completedTemplate = perform_erb_transformation_as_yaml(erbTemplate, manifest)
+    else
+      completedTemplate = perform_erb_transformation_as_string(erbTemplate, manifest)
+    end
+    completedTemplate
+  end
+
+  def yml_compare(output, actual)
+    expected = File.read(output)
+    expect(actual).to yaml_eq(expected)
+  end
+
+  def str_compare(output, actual)
+    expected = File.read(output)
+    expect(actual).to eq(expected)
+  end
+
+  context 'application.yml' do
+    let(:manifest) {'spec/input/all-properties-set.yml'}
+    let(:output_application_yaml) {'spec/compare/all-properties-boot-application.yml'}
+    let(:erb_template) {'../jobs/uaa/templates/config/boot/application.yml.erb'}
+    let(:as_yml) {true}
+    let(:generated_uaa_manifest) {generate_cf_manifest(manifest)}
+    let(:parsed_yaml) {read_and_parse_string_template(erb_template, generated_uaa_manifest, as_yml)}
+
+
+
+    context 'when using default values' do
+      it 'yaml matches the expected result' do
+        yml_compare(output_application_yaml, parsed_yaml.to_yaml)
+      end
+    end
+
+    context 'when uaa.localhost_http_port is valid' do
+      before(:each) do
+        generated_uaa_manifest['properties']['uaa']['localhost_http_port'] = 2000
+      end
+
+      it 'has an http connector with value of uaa.localhost_http_port' do
+        expect(parsed_yaml['server']['http']['port']).to eq 2000
+      end
+    end
+
+    context 'when uaa.localhost_http_port is invalid (-1)' do
+      before(:each) do
+        generated_uaa_manifest['properties']['uaa']['localhost_http_port'] = -1
+      end
+
+      it 'returns an error' do
+        expect {parsed_yaml}.to raise_error(ArgumentError, 'Invalid value (-1) specified for uaa.localhost_http_port, please specify a valid port number in this range [1024-65535]')
+      end
+    end
+
+    context 'when uaa.localhost_http_port is invalid (1023)' do
+      before(:each) do
+        generated_uaa_manifest['properties']['uaa']['localhost_http_port'] = 1023
+      end
+
+      it 'returns an error' do
+        expect {parsed_yaml}.to raise_error(ArgumentError, 'Invalid value (1023) specified for uaa.localhost_http_port, please specify a valid port number in this range [1024-65535]')
+      end
+    end
+
+    context 'when uaa.localhost_http_port is invalid (65536)' do
+      before(:each) do
+        generated_uaa_manifest['properties']['uaa']['localhost_http_port'] = 65536
+      end
+
+      it 'returns an error' do
+        expect {parsed_yaml}.to raise_error(ArgumentError, 'Invalid value (65536) specified for uaa.localhost_http_port, please specify a valid port number in this range [1024-65535]')
+      end
+    end
+
+    context 'when uaa.ssl.port is valid' do
+      before(:each) do
+        generated_uaa_manifest['properties']['uaa']['ssl']['port'] = 3333
+      end
+
+      it 'has an http connector with value of uaa.localhost_http_port' do
+        expect(parsed_yaml['server']['port']).to eq 3333
+      end
+    end
+
+    context 'when uaa.ssl.port is invalid (-1)' do
+      before(:each) do
+        generated_uaa_manifest['properties']['uaa']['ssl']['port'] = -1
+      end
+
+      it 'returns an error' do
+        expect {parsed_yaml}.to raise_error(ArgumentError, 'Invalid value (-1) specified for uaa.ssl.port, please specify a valid port number in this range [1024-65535]')
+      end
+    end
+
+    context 'when uaa.ssl.port is invalid (1023)' do
+      before(:each) do
+        generated_uaa_manifest['properties']['uaa']['ssl']['port'] = 1023
+      end
+
+      it 'returns an error' do
+        expect {parsed_yaml}.to raise_error(ArgumentError, 'Invalid value (1023) specified for uaa.ssl.port, please specify a valid port number in this range [1024-65535]')
+      end
+    end
+
+    context 'when uaa.ssl.port is invalid (65536)' do
+      before(:each) do
+        generated_uaa_manifest['properties']['uaa']['ssl']['port'] = 65536
+      end
+
+      it 'returns an error' do
+        expect {parsed_yaml}.to raise_error(ArgumentError, 'Invalid value (65536) specified for uaa.ssl.port, please specify a valid port number in this range [1024-65535]')
+      end
+    end
+
+    context 'when uaa.localhost_http_port is the same as uaa.ssl.port' do
+      before(:each) do
+        generated_uaa_manifest['properties']['uaa']['ssl']['port'] = 9090
+        generated_uaa_manifest['properties']['uaa']['localhost_http_port'] = 9090
+      end
+
+      it 'returns an error' do
+        expect {parsed_yaml}.to raise_error(ArgumentError, 'Please specify different values for uaa.ssl.port and uaa.localhost_http_port')
+      end
+    end
+
+    context 'when uaa.keepalive_timeout is invalid (-1)' do
+      before(:each) do
+        generated_uaa_manifest['properties']['uaa']['keepalive_timeout'] = -2
+      end
+
+      it 'returns an error' do
+        expect {parsed_yaml}.to raise_error(ArgumentError, 'Invalid value (-2) specified for uaa.keepalive_timeout, please specify either a positive integer value or -1')
+      end
+    end
+
+    context 'using bosh links' do
+      let(:internal_proxies) do
+        parsed_yaml['server']['tomcat']['remoteip']['internal-proxies']
+      end
+
+      context 'when uaa.proxy_ips_regex is in the manifest' do
+        it 'includes the proxy_ips_regex when uaa.proxy.servers not set and bosh links not available' do
+          generated_uaa_manifest['properties']['uaa']['proxy']['servers'] = []
+          generated_uaa_manifest['properties']['uaa']['proxy_ips_regex'] = 'proxy_ips_regex'
+          generated_uaa_manifest['links'] = {}
+
+          expect(internal_proxies).to include('proxy_ips_regex')
+        end
+
+        it 'includes proxy_ips_regex when uaa.proxy.servers are set and bosh links are not available' do
+          generated_uaa_manifest['properties']['uaa']['proxy']['servers'] = ['1.1.1.1']
+          generated_uaa_manifest['properties']['uaa']['proxy_ips_regex'] = 'proxy_ips_regex'
+          generated_uaa_manifest['links'] = {}
+
+          expect(internal_proxies).to include('proxy_ips_regex')
+        end
+
+        it 'includes proxy_ips_regex when uaa.proxy.servers not set and bosh link is available' do
+          generated_uaa_manifest['properties']['uaa']['proxy']['servers'] = []
+          generated_uaa_manifest['properties']['uaa']['proxy_ips_regex'] = 'proxy_ips_regex'
+          generated_uaa_manifest['links'] = {
+              'router' => {'instances' => [{'address' => 'linked-address'}]}
+          }
+
+          expect(internal_proxies).to include('proxy_ips_regex')
+        end
+
+        it 'includes proxy_ips_regex when uaa.proxy.servers is set and bosh link is available' do
+          generated_uaa_manifest['properties']['uaa']['proxy']['servers'] = ['1.12.3.4']
+          generated_uaa_manifest['properties']['uaa']['proxy_ips_regex'] = 'proxy_ips_regex'
+          generated_uaa_manifest['links'] = {
+              'router' => {'instances' => [{'address' => 'linked-address'}]}
+          }
+
+          expect(internal_proxies).to include('proxy_ips_regex')
+        end
+      end
+      context 'when uaa.proxy.servers is left to default value in the manifest' do
+        before(:each) do
+          generated_uaa_manifest['properties']['uaa']['proxy_ips_regex'] = 'proxy_ips_regex'
+          generated_uaa_manifest['properties']['uaa']['proxy']['servers'] = []
+        end
+
+        let(:generated_uaa_manifest) {generate_cf_manifest('spec/input/all-properties-set.yml', links)}
+
+        context 'when a bosh-link is available' do
+          let(:links) {{
+            'router' => {'instances' => [{'address' => 'linked-address'}]}
+          }}
+
+          it 'uses the bosh-linked router config' do
+            expect(internal_proxies).to eq('linked-address|proxy_ips_regex')
+          end
+        end
+
+        context 'when there is no bosh-link available' do
+          before(:each) do
+            generated_uaa_manifest['properties']['uaa']['proxy_ips_regex'] = ''
+            generated_uaa_manifest['properties']['uaa']['proxy']['servers'] = []
+          end
+          let(:links) {{}}
+
+          it 'uses the default internal proxies list' do
+            expect(internal_proxies).to eq '10.d{1,3}.d{1,3}.d{1,3}|192.168.d{1,3}.d{1,3}|169.254.d{1,3}.d{1,3}|127.d{1,3}.d{1,3}.d{1,3}|172.1[6-9]{1}.d{1,3}.d{1,3}|172.2[0-9]{1}.d{1,3}.d{1,3}|172.3[0-1]{1}.d{1,3}.d{1,3}'
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/compare/all-properties-boot-application.yml
+++ b/spec/compare/all-properties-boot-application.yml
@@ -1,0 +1,35 @@
+server:
+  http:
+    port: 55555
+    address: "127.0.0.1"
+    connection-timeout: 20000
+    keep-alive-timeout: 120000
+    max-http-header-size: 14336
+    bind-on-init: true
+  port: 33333
+  max-http-header-size: 14336
+  tomcat:
+    basedir: "/var/vcap/data/uaa/boot/"
+    connection-timeout: 20000
+    keep-alive-timeout: 120000
+    remoteip:
+      remote-ip-header: "x-forwarded-for"
+      protocol-header: "x-forwarded-proto"
+      internal-proxies: "127\\.1\\.0\\.1|127\\.1\\.0\\.2|127\\.1\\.0\\.3|10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|192\\.168\\.\\d{1,3}\\.\\d{1,3}|169\\.254\\.\\d{1,3}\\.\\d{1,3}|127\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+      port-header: "X-Forwarded-Port"
+    accesslog:
+      enabled: true
+      directory: "/var/vcap/sys/log/uaa"
+      prefix: "localhost_access"
+      suffix: ".log"
+      rotate: false
+      pattern: "%h %l %u %t &quot;%m %U %H&quot; %s %{Content-Length}i %b &quot;X-Vcap-Request-Id: %{X-Vcap-Request-Id}i&quot; %I"
+  ssl:
+    enabled: true
+    enabled-protocols: "TLSv1.2,TLSv1.3"
+    ciphers: "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384"
+    protocol: TLS
+    key-store: "/var/vcap/data/uaa/uaa_keystore.p12"
+    key-store-type: "PKCS12"
+    key-alias: "uaa_ssl_cert"
+    key-store-password: "k0*l*s3cur1tyr0ck$"

--- a/spec/support/yaml_eq.rb
+++ b/spec/support/yaml_eq.rb
@@ -23,7 +23,8 @@ RSpec::Matchers.define :yaml_eq do |expected|
       end
 
       puts
-      puts `spiff diff #{expected_manifest.path} #{actual_manifest.path}`
+      # in case the spiff command doesn't exist. Don't fail
+      puts `spiff diff #{expected_manifest.path} #{actual_manifest.path} || true`
   end
 
   def object_eq(actual, expected, path=[])

--- a/src/acceptance_tests/uaa-release_test.go
+++ b/src/acceptance_tests/uaa-release_test.go
@@ -239,7 +239,7 @@ func assertUAAIsHealthy(healthCheckPath string) {
 }
 
 func verifyTomcatIsUsingCorrectTruststore() bool {
-	tomcatProcessCmdOutput := runCommandOnUaaViaSsh("ps aux | grep tomcat")
+	tomcatProcessCmdOutput := runCommandOnUaaViaSsh("ps aux | grep -E 'tomcat|uaa-boot.war'")
 	return strings.Contains(tomcatProcessCmdOutput, "-Djavax.net.ssl.trustStore=/var/vcap/data/uaa/cert-cache/cacerts")
 }
 


### PR DESCRIPTION
Overview

Boot is enabled by default

1. Added a configuration option `runtime.tomcat.enabled` with default `false` in `jobs/uaa/spec` (we can consider setting it to true)
2. Added unit test for `application.yml` file generation
3. Bumped the UAA submodule to a Spring Boot one

