### PR TITLE
Cleanup dir changes

### DIFF
--- a/jobs/uaa/templates/bin/pre-start.erb
+++ b/jobs/uaa/templates/bin/pre-start.erb
@@ -213,6 +213,8 @@ configure_tomcat
 
 configure_spring_boot
 
+ensure_persistent_cert_dir_secure
+
 rm -rf $TMP_DIR
 
 log "Completed"


### PR DESCRIPTION
left over or a more secure enhancement from AI review

Why: configure_tomcat runs chown -R vcap:vcap /var/vcap/data/uaa/, which recursively re-chowns cert-cache back to vcap:vcap, undoing the root:root 0700 that ensure_persistent_cert_dir_secure set. Calling it again at the end restores the correct ownership and permissions
  after the chown -R has run.