### PR TITLE
improve startup scripts and logs

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -203,7 +203,7 @@ properties:
     description: "The url to use as the issuer URI"
   uaa.logging_level:
     description: Set UAA logging level.  (e.g. TRACE, DEBUG, INFO)
-    default: DEBUG
+    default: INFO
   uaa.logging.format.timestamp:
     description: "Format for timestamp in component logs. Valid values are 'rfc3339', 'rfc3339-legacy', and 'deprecated'. 'rfc3339' sets the format to be {yyyy-MM-dd'T'HH:mm:ss.nnnnnn}{GMT+0}Z which is rfc3339 compliant but additionally has microsecond precision and is set to UTC timezone. 'rfc3339-legacy' sets the time format to be yyyy-MM-dd'T'HH:mm:ss.SSSXXX. 'deprecated' sets the time format to be yyyy-MM-dd HH:mm:ss.SSS."
     default: rfc3339
@@ -580,7 +580,10 @@ properties:
       When set to `legacy`, allow unsafe matching of redirect URIs.
       For example, https://example.com would also match all subdomains and all paths of https://example.com.
       When set to `exact`, will provide OAuth2 spec-compliant (RFC6749) exact redirect URI matching.
-    default: legacy
+      NOTE: changing this from `legacy` to `exact` is a breaking change for clients that rely on
+      wildcard or subdomain redirect URI matching. Review all registered client redirect URIs before
+      enabling `exact` mode in existing deployments.
+    default: exact
 
   # Clients
   uaa.clients:

--- a/jobs/uaa/templates/bin/pre-start.erb
+++ b/jobs/uaa/templates/bin/pre-start.erb
@@ -176,6 +176,17 @@ function configure_tomcat {
     chown -R vcap:vcap /var/vcap/data/uaa/
 }
 
+function resecure_cert_cache {
+    # configure_tomcat hands all of /var/vcap/data/uaa/ to vcap via chown -R.
+    # Re-secure cert-cache so that the vcap process cannot tamper with the
+    # truststore between deploys. vcap retains read-only access via the
+    # execute bit on the directory and world-readable mode on the files.
+    chown root:root "${PERSISTENT_CERTS_DIR}"
+    chmod 0711 "${PERSISTENT_CERTS_DIR}"
+    find "${PERSISTENT_CERTS_DIR}" -maxdepth 1 -type f -exec chown root:root {} +
+    find "${PERSISTENT_CERTS_DIR}" -maxdepth 1 -type f -exec chmod 0644 {} +
+}
+
 function configure_spring_boot {
     # When run with bpm, the vcap user does not have permissions to read
     # files in the jobs and packages directories. Consequently, we move
@@ -212,6 +223,8 @@ process_certs
 configure_tomcat
 
 configure_spring_boot
+
+resecure_cert_cache
 
 rm -rf $TMP_DIR
 

--- a/jobs/uaa/templates/config/log4j2.properties.erb
+++ b/jobs/uaa/templates/config/log4j2.properties.erb
@@ -15,7 +15,7 @@ case logging_format_timestamp_value
 end
 %>
 property.log_directory = /var/vcap/sys/log/uaa
-property.log_pattern=[<%= timestamp_format %>] uaa%X{context} - %pid [%t] - [%X{traceId},%X{spanId}] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=)([^&]*)}{<redacted>}%n
+property.log_pattern=[<%= timestamp_format %>] uaa%X{context} - %pid [%t] - [%X{traceId},%X{spanId}] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=|code=|access_token=|refresh_token=|id_token=)([^&\s]*)}{<redacted>}%n
 
 appender.uaaDefaultAppender.type = File
 appender.uaaDefaultAppender.name = UaaDefaultAppender

--- a/scripts/perform-release.sh
+++ b/scripts/perform-release.sh
@@ -7,8 +7,7 @@ CYAN='\033[0;36m'
 BOLD='\033[0;1m'
 NC='\033[0m' # No Color
 
-TMPDIR=/tmp
-SAVEDIR=$TMPDIR/uaa-release-save
+SAVEDIR=$(mktemp -d)
 RELEASES=$SAVEDIR/releases
 FINAL_BUILDS=$SAVEDIR/.final_builds
 
@@ -123,12 +122,16 @@ git fetch --all --prune > /dev/null
 
 echo -e "${CYAN}Creating bosh UAA-release ${GREEN} ${1} ${NC} using `bosh -v`"
 
-# we save private.yml to a temp directory
-# just in case it gets deleted during branch switch
+# we save private.yml to a secure temp file so it survives branch switches
+# and is cleaned up automatically on exit.
+PRIVATE_YML_COPY=$(mktemp)
+chmod 0600 "${PRIVATE_YML_COPY}"
+trap 'rm -f "${PRIVATE_YML_COPY}"' EXIT
+
 if [ "$#" -ge 3 ]; then
-    cp $3 /tmp/private.yml
+    cp "$3" "${PRIVATE_YML_COPY}"
 elif [ -f config/private.yml ]; then
-    cp config/private.yml /tmp/private.yml
+    cp config/private.yml "${PRIVATE_YML_COPY}"
 else
     echo -e "${RED}ERROR:${NC} Missing private.yml file" >&2
     usage
@@ -140,7 +143,7 @@ git checkout $branch_to_release_from
 sub_update
 
 # restore private.yml in case it got deleted
-cp /tmp/private.yml config/
+cp "${PRIVATE_YML_COPY}" config/
 
 echo -e "${CYAN}Building tarball ${GREEN}${1}${NC} and tag with ${GREEN}v${1}${NC}"
 # create a release tar ball - and a dev release

--- a/spec/compare/all-properties-set-log4j2-defaults.properties
+++ b/spec/compare/all-properties-set-log4j2-defaults.properties
@@ -1,0 +1,85 @@
+status = error
+dest = err
+name = UaaLog
+
+property.log_directory = /var/vcap/sys/log/uaa
+property.log_pattern=[%d{yyyy-MM-dd'T'HH:mm:ss.nnnnnn}{GMT+0}Z] uaa%X{context} - %pid [%t] - [%X{traceId},%X{spanId}] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=|code=|access_token=|refresh_token=|id_token=)([^&\s]*)}{<redacted>}%n
+
+appender.uaaDefaultAppender.type = File
+appender.uaaDefaultAppender.name = UaaDefaultAppender
+appender.uaaDefaultAppender.fileName = ${log_directory}/uaa.log
+appender.uaaDefaultAppender.layout.type = PatternLayout
+appender.uaaDefaultAppender.layout.pattern = ${log_pattern}
+
+appender.uaaAuditAppender.type = File
+appender.uaaAuditAppender.name = UaaAuditAppender
+appender.uaaAuditAppender.fileName = ${log_directory}/uaa_events.log
+appender.uaaAuditAppender.layout.type = PatternLayout
+appender.uaaAuditAppender.layout.pattern = ${log_pattern}
+
+rootLogger.level = info
+rootLogger.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.UAAAudit.name = UAA.Audit
+logger.UAAAudit.level = info
+logger.UAAAudit.additivity = true
+logger.UAAAudit.appenderRef.auditEventLog.ref = UaaAuditAppender
+
+
+# These loggers have a configurable level
+logger.cfIdentity.name = org.cloudfoundry.identity
+logger.cfIdentity.level = INFO
+logger.cfIdentity.additivity = false
+logger.cfIdentity.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springSecurity.name = org.springframework.security
+logger.springSecurity.level = INFO
+logger.springSecurity.additivity = false
+logger.springSecurity.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springJdbc.name = org.springframework.jdbc
+logger.springJdbc.level = INFO
+logger.springJdbc.additivity = false
+logger.springJdbc.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+
+# These loggers have a fixed level of "info"
+logger.springWebStandardServletEnvironment.name = org.springframework.web.context.support.StandardServletEnvironment
+logger.springWebStandardServletEnvironment.level = info
+logger.springWebStandardServletEnvironment.additivity = false
+logger.springWebStandardServletEnvironment.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.apacheHttpWire.name = org.apache.http.wire
+logger.apacheHttpWire.level = info
+logger.apacheHttpWire.additivity = false
+logger.apacheHttpWire.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springAopAspectJExpressionPointcut.name = org.springframework.aop.aspectj.AspectJExpressionPointcut
+logger.springAopAspectJExpressionPointcut.level = info
+logger.springAopAspectJExpressionPointcut.additivity = false
+logger.springAopAspectJExpressionPointcut.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springBeansDefaultListableBeanFactory.name = org.springframework.beans.factory.support.DefaultListableBeanFactory
+logger.springBeansDefaultListableBeanFactory.level = info
+logger.springBeansDefaultListableBeanFactory.additivity = false
+logger.springBeansDefaultListableBeanFactory.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springBeansDisposableBeanAdaptor.name = org.springframework.beans.factory.support.DisposableBeanAdapter
+logger.springBeansDisposableBeanAdaptor.level = info
+logger.springBeansDisposableBeanAdaptor.additivity = false
+logger.springBeansDisposableBeanAdaptor.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springSecurityLdapAuthenticationProvider.name = org.springframework.security.ldap.authentication.LdapAuthenticationProvider
+logger.springSecurityLdapAuthenticationProvider.level = info
+logger.springSecurityLdapAuthenticationProvider.additivity = false
+logger.springSecurityLdapAuthenticationProvider.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springSecurityFilterBasedUserSearch.name = org.springframework.security.ldap.search.FilterBasedLdapUserSearch
+logger.springSecurityFilterBasedUserSearch.level = info
+logger.springSecurityFilterBasedUserSearch.additivity = false
+logger.springSecurityFilterBasedUserSearch.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springWeb.name = org.springframework.web
+logger.springWeb.level = info
+logger.springWeb.additivity = false
+logger.springWeb.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender

--- a/spec/compare/all-properties-set-log4j2.properties
+++ b/spec/compare/all-properties-set-log4j2.properties
@@ -3,7 +3,7 @@ dest = err
 name = UaaLog
 
 property.log_directory = /var/vcap/sys/log/uaa
-property.log_pattern=[%d{yyyy-MM-dd'T'HH:mm:ss.nnnnnn}{GMT+0}Z] uaa%X{context} - %pid [%t] - [%X{traceId},%X{spanId}] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=)([^&]*)}{<redacted>}%n
+property.log_pattern=[%d{yyyy-MM-dd'T'HH:mm:ss.nnnnnn}{GMT+0}Z] uaa%X{context} - %pid [%t] - [%X{traceId},%X{spanId}] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=|code=|access_token=|refresh_token=|id_token=)([^&\s]*)}{<redacted>}%n
 
 appender.uaaDefaultAppender.type = File
 appender.uaaDefaultAppender.name = UaaDefaultAppender

--- a/spec/compare/all-properties-set-uaa-defaults.yml
+++ b/spec/compare/all-properties-set-uaa-defaults.yml
@@ -1,0 +1,724 @@
+---
+name: uaa
+encryption:
+  active_key_label: key1
+  encryption_keys:
+    - label: key1
+      passphrase: 12345678
+disableInternalAuth: true
+disableInternalUserManagement: true
+issuer:
+  uri: http://all-properties-set:8888/uaa
+spring_profiles: mysql,ldap
+logging:
+  config: "/var/vcap/jobs/uaa/config/log4j2.properties"
+database:
+  url: jdbc:mysql://10.244.0.30:5524/uaadb?useSSL=true&enabledSslProtocolSuites=TLSv1.2&tcpKeepAlive=true&usePipelineAuth=false
+  username: uaaadmin
+  password: admin
+  maxactive: 101
+  maxidle: 11
+  minidle: 1
+  removeabandoned: true
+  logabandoned: false
+  abandonedtimeout: 301
+  caseinsensitive: true
+  testwhileidle: true
+
+delete:
+  clients:
+    - client-to-be-deleted-1
+    - client-to-be-deleted-2
+  users:
+    - user-to-be-deleted-1
+    - user-to-be-deleted-2
+  identityProviders:
+    - google
+    - octa
+
+authentication:
+  enableUriEncodingCompatibilityMode: false
+  policy:
+    lockoutAfterFailures: 5
+    countFailuresWithinSeconds: 1200
+    lockoutPeriodSeconds: 300
+    global:
+      lockoutAfterFailures: 5
+      countFailuresWithinSeconds: 1200
+      lockoutPeriodSeconds: 300
+password:
+  policy:
+    minLength: 0
+    maxLength: 255
+    requireUpperCaseCharacter: 0
+    requireLowerCaseCharacter: 0
+    requireDigit: 0
+    requireSpecialCharacter: 0
+    expirePasswordInMonths: 0
+    global:
+      minLength: 0
+      maxLength: 255
+      requireUpperCaseCharacter: 0
+      requireLowerCaseCharacter: 0
+      requireDigit: 0
+      requireSpecialCharacter: 0
+      expirePasswordInMonths: 0
+zones:
+  internal:
+    hostnames:
+    - login.test-domain.com
+    - host1.test
+    - host2.test
+    - host3.test
+jwt:
+  token:
+    queryString:
+      enabled: false
+    revocable: true
+    policy:
+      accessTokenValiditySeconds: 43200
+      refreshTokenValiditySeconds: 2592000
+      global:
+        accessTokenValiditySeconds: 43200
+        refreshTokenValiditySeconds: 2592000
+      activeKeyId: key-1
+      keys:
+        key-1:
+          signingKey: |
+            -----BEGIN RSA PRIVATE KEY-----
+            MIICXgIBAAKBgQDfTLadf6QgJeS2XXImEHMsa+1O7MmIt44xaL77N2K+J/JGpfV3
+            AnkyB06wFZ02sBLB7hko42LIsVEOyTuUBird/3vlyHFKytG7UEt60Fl88SbAEfsU
+            JN1i1aSUlunPS/NCz+BKwwKFP9Ss3rNImE9Uc2LMvGy153LHFVW2zrjhTwIDAQAB
+            AoGBAJDh21LRcJITRBQ3CUs9PR1DYZPl+tUkE7RnPBMPWpf6ny3LnDp9dllJeHqz
+            a3ACSgleDSEEeCGzOt6XHnrqjYCKa42Z+Opnjx/OOpjyX1NAaswRtnb039jwv4gb
+            RlwT49Y17UAQpISOo7JFadCBoMG0ix8xr4ScY+zCSoG5v0BhAkEA8llNsiWBJF5r
+            LWQ6uimfdU2y1IPlkcGAvjekYDkdkHiRie725Dn4qRiXyABeaqNm2bpnD620Okwr
+            sf7LY+BMdwJBAOvgt/ZGwJrMOe/cHhbujtjBK/1CumJ4n2r5V1zPBFfLNXiKnpJ6
+            J/sRwmjgg4u3Anu1ENF3YsxYabflBnvOP+kCQCQ8VBCp6OhOMcpErT8+j/gTGQUL
+            f5zOiPhoC2zTvWbnkCNGlqXDQTnPUop1+6gILI2rgFNozoTU9MeVaEXTuLsCQQDC
+            AGuNpReYucwVGYet+LuITyjs/krp3qfPhhByhtndk4cBA5H0i4ACodKyC6Zl7Tmf
+            oYaZoYWi6DzbQQUaIsKxAkEA2rXQjQFsfnSm+w/9067ChWg46p4lq5Na2NpcpFgH
+            waZKhM1W0oB8MX78M+0fG3xGUtywTx0D4N7pr1Tk2GTgNw==
+            -----END RSA PRIVATE KEY-----
+    claims:
+      exclude:
+      - authorities
+      - username
+    signing-key: |
+      signing-key with some
+      line feeds in it
+    verification-key: |
+      verification-key with some
+      line feeds in it
+    refresh:
+      restrict_grant: true
+      unique: true
+      rotate: true
+      format: opaque
+cors:
+  default:
+    allowed:
+      headers:
+        - Accept
+        - Authorization
+        - Content-Type
+        - X-Requested-With
+      origin:
+        - ^localhost$
+        - ^.*\.localhost$
+      uris:
+        - ^/uaa/userinfo$
+        - ^/uaa/logout\.do$
+      methods:
+        - GET
+        - PUT
+        - POST
+        - DELETE
+        - OPTIONS
+      credentials: true
+    max_age: 10
+  xhr:
+    allowed:
+      headers:
+        - Accept
+        - Authorization
+        - Content-Type
+        - X-Requested-With
+      origin:
+        - ^localhost$
+        - ^.*\.localhost$
+      uris:
+        - ^/uaa/userinfo$
+        - ^/uaa/logout\.do$
+      methods:
+        - GET
+        - OPTIONS
+      credentials: true
+    max_age: 10
+  enforceSystemZonePolicyInAllZones: true
+csp:
+  script-src:
+    - "'self'"
+oauth:
+  client:
+    secret:
+      policy:
+        minLength: 8
+        maxLength: 128
+        requireUpperCaseCharacter: 1
+        requireLowerCaseCharacter: 3
+        requireDigit: 2
+        requireSpecialCharacter: 0
+        expireSecretInMonths: 7
+  clients:
+    cf:
+      id: cf
+      override: true
+      authorized-grant-types: password,refresh_token
+      scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write
+      authorities: uaa.none
+      access-token-validity: 600
+      refresh-token-validity: 2592000
+      secret: ""
+    app:
+      id: app
+      override: true
+      secret: app-secret
+      authorized-grant-types: authorization_code,client_credentials,refresh_token
+      authorities: test_resource.test_action
+      scope: test_resource.test_action,test_resource.other_action
+      redirect-uri: http://login.example.com
+      autoapprove:
+      - test_resource.test_action
+      - test_resource.other_action
+      app-launch-url: http://myapppage.com
+      show-on-homepage: true
+      app-icon: iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAD1BMVEWZttQvMDEoKisqKywAAAApvvoVAAAAGElEQVQYlWNgYUQBLAxMDCiAeXgLoHsfAD03AHOyfqy1AAAAAElFTkSuQmCC
+    app-with-yaml-scopes:
+      id: app-with-yaml-scopes
+      override: true
+      secret: app-secret
+      authorized-grant-types: authorization_code,client_credentials,refresh_token
+      authorities: test_resource.test_action
+      scope: test_resource.test_action,test_resource.other_action
+      redirect-uri: http://login.example.com
+      autoapprove:
+      - test_resource.test_action
+      - test_resource.other_action
+      app-launch-url: http://myapppage.com
+      show-on-homepage: true
+      app-icon: iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAD1BMVEWZttQvMDEoKisqKywAAAApvvoVAAAAGElEQVQYlWNgYUQBLAxMDCiAeXgLoHsfAD03AHOyfqy1AAAAAElFTkSuQmCC
+    admin:
+      authorized-grant-types: client_credentials
+      authorities: clients.read,clients.write,clients.secret,uaa.admin,scim.read,scim.write,password.write
+      id: admin
+      secret: adminsecret
+    implicit_ok:
+      id: implicit_ok
+      authorities: uaa.none
+      authorized-grant-types: implicit
+      redirect-uri: "http://some.redirect.com/callback"
+      override: true
+      show-on-homepage: true
+      scope: openid
+  user:
+    authorities:
+    - openid
+    - scim.me
+    - cloud_controller.read
+    - cloud_controller.write
+    - approvals.me
+    - oauth.approvals
+    - notification_preferences.read
+    - notification_preferences.write
+    - profile
+    - roles
+    - user_attributes
+    - uaa.offline_token
+scim:
+  userids_enabled: true
+  user:
+    override: true
+  users:
+  - shortuser|password|shortuser|||group1,group2|uaa
+  - longuser|password|email|first name|lastName|group1,group2|origin-value - most
+    commonly uaa
+  groups:
+    my-test-group: My test group description
+    another-group: Another group description
+  external_groups:
+    origin1:
+      external_group1:
+      - internal_group1
+      - internal_group2
+      - internal_group3
+      external_group2:
+      - internal_group2
+      - internal_group4
+    origin2:
+      external_group3:
+      - internal_group3
+      - internal_group4
+      - internal_group5
+    ldap:
+      "cn=admin\\, test,ou=scopes,dc=test,dc=com":
+      - ldap.test
+ldap:
+  override: false
+  ldapdebug: Ldap configured through UAA
+  profile:
+    file: ldap/ldap-search-and-bind.xml
+  ssl:
+    tls: simple
+    skipverification: true
+    sslCertificate: ldap-ssl-cert
+  base:
+    url: ldap://192.168.50.4:389/
+    mailAttributeName: mail
+    mailSubstitute: "{0}@test.com"
+    mailSubstituteOverridesLdap: true
+    referral: follow
+    userDn: cn=admin,dc=test,dc=com
+    password: password
+    searchBase: dc=test,dc=com
+    searchFilter: cn={0}
+  addShadowUserOnLogin: false
+  emailDomain:
+  - whitelist-domain1.org
+  - whitelist-domain2.org
+  attributeMappings:
+    given_name: givenName
+    family_name: sn
+    phone_number: telephoneNumber
+    user.attribute.name-of-attribute-in-uaa-id-token: name-of-attribute-in-ldap-record
+    user.attribute.name-of-other-attribute-in-uaa-id-token: name-of-other-attribute-in-ldap-record
+  storeCustomAttributes: false
+  externalGroupsWhitelist:
+  - admin
+  - user
+  groups:
+    file: ldap/ldap-groups-map-to-scopes.xml
+    searchBase: dc=test,dc=com
+    groupRoleAttribute: spring.security.ldap.dn
+    groupSearchFilter: member={0}
+    searchSubtree: true
+    maxSearchDepth: 10
+
+assetBaseUrl: "/resources/testing"
+logout:
+  redirect:
+    url: "/"
+    parameter:
+      disable: false
+
+require_https: true
+https_port: 33333
+
+uaa:
+  url: http://all-properties-set:8888/uaa
+  limitedFunctionality:
+    statusFile: /var/vcap/data/uaa/test_bbr_limited_mode.lock
+    whitelist:
+      endpoints:
+      - /oauth/authorize/**
+      - /oauth/token/**
+      - /check_token/**
+      methods:
+      - GET
+      - HEAD
+  shutdown:
+    sleep: 10000
+  oauth:
+    redirect_uri:
+      allow_unsafe_matching: false
+
+links:
+  global:
+    passwd: "https://{zone.subdomain}.myaccountmanager.domain.com/z/{zone.id}/forgot_password"
+    signup: "https://{zone.subdomain}.myaccountmanager.domain.com/z/{zone.id}/create_account"
+    homeRedirect: "https://{zone.subdomain}.myaccountmanager.domain.com/z/{zone.id}/success"
+  passwd: "/reset_password"
+  signup: http://signup.somewhere.else
+  custom: http://custom.link
+  homeRedirect: http://custom.home.redirect
+login:
+  url: http://all-properties-set:8888/uaa
+  defaultIdentityProvider: uaa
+  idpDiscoveryEnabled: true
+  accountChooserEnabled: true
+  aliasEntitiesEnabled: true
+  checkOriginEnabled: true
+  allowOriginLoop: false
+  entityBaseURL: http://all-properties-set:8888/uaa
+  entityID: all-properties-set:8888/uaa
+  prompt:
+    username:
+      text: Username
+    password:
+      text: Secret
+  authorize:
+    url: http://all-properties-set:8888/uaa/oauth/authorize
+  saml:
+    activeKeyId: key1
+    keys:
+      key1:
+        key: |
+          -----BEGIN RSA PRIVATE KEY-----
+          MIIEogIBAAKCAQEArRkvkddLUoNyuvu0ktkcLL0CyGG8Drh9oPsaVOLVHJqB1Ebr
+          oNMTPbY0HPjuD5WBDZTi3ftNLp1mPn9wFy6FhMTvIYeQmTskH8m/kyVReXG/zfWq
+          a4+V6UW4nmUcvfF3YNrHvN5VPTWTJrc2KBzseWQ70OaBNfBi6z4XbdOF45dDfck2
+          oRnasinUv+rG+PUl7x8OjgdVyyen6qeCQ6xt8W9fHg//Nydlfwb3/L+syPoBujdu
+          Hai7GoLUzm/zqOM9dhlR5mjuEJ3QUvnmGKrGDoeHFog0CMgLC+C0Z4ZANB6GbjlM
+          bsQczsaYxHMqAMOnOe6xIXUrPOoc7rclwZeHMQIDAQABAoIBAAFB2ZKZmbZztfWd
+          tmYKpaW9ibOi4hbJSEBPEpXjP+EBTkgYa8WzQsSD+kTrme8LCvDqT+uE076u7fsu
+          OcYxVE7ujz4TGf3C7DQ+5uFOuBTFurroOeCmHlSfaQPdgCPxCQjvDdxVUREsvnDd
+          i8smyqDnFXgi9HVL1awXu1vU2XgZshfl6wBOCNomVMCN8mVcBQ0KM88SUvoUwM7i
+          sSdj1yQV16Za8+nVnMW41FMHegVRd3Y5EsXJfwGuXnZMIG87PavH1nUqn9NOFq9Y
+          kb4SeOO47PaMxv7jMaXltVVokdGH8L/BY4we8tBL+wVeUJ94aYx/Q/LUAtRPbKPS
+          ZSEi/7ECgYEA3dUg8DXzo59zl5a8kfz3aoLl8RqRYzuf8F396IuiVcqYlwlWOkZW
+          javwviEOEdZhUZPxK1duXKTvYw7s6eDFwV+CklTZu4A8M3Os0D8bSL/pIKqcadt5
+          JClIRmOmmQpj9AYhSdBTdQtJGjVDaDXJBb7902pDm9I4jMFbjAKLZNsCgYEAx8J3
+          Y1c7GwHw6dxvTywrw3U6z1ILbx2olVLY6DIgZaMVT4EKTAv2Ke4xF4OZYG+lLRbt
+          hhOHYzRMYC38MNl/9RXHBgUlQJXOQb9u644motl5dcMvzIIuWFCn5vXxR2C3McNy
+          vPdzYS2M64xRGy+IENtPSCcUs9C99bEajRcuG+MCgYAONabEfFA8/OvEnA08NL4M
+          fpIIHbGOb7VRClRHXxpo8G9RzXFOjk7hCFCFfUyPa/IT7awXIKSbHp2O9NfMK2+/
+          cUTF5tWDozU3/oLlXAV9ZX2jcApQ5ZQe8t4EVEHJr9azPOlI9yVBbBWkriDBPiDA
+          U3mi3z2xb4fbzE726vrO3QKBgA6PfTZPgG5qiM3zFGX3+USpAd1kxJKX3dbskAT0
+          ymm+JmqCJGcApDPQOeHV5NMjsC2GM1AHkmHHyR1lnLFO2UXbDYPB0kJP6RXfx00C
+          MozCP1k3Hf/RKWGkl2h9WtXyFchZz744Zz+ZG2F7+9l4cHmSEshWmOq2d3I2M5I/
+          M0wzAoGAa2oM4Q6n+FMHl9e8H+2O4Dgm7wAdhuZI1LhnLL6GLVC1JTmGrz/6G2TX
+          iNFhc0lnDcVeZlwg4i7M7MH8UFdWj3ZEylsXjrjIspuAJg7a/6qmP9s2ITVffqYk
+          2slwG2SIQchM5/0uOiP9W0YIjYEe7hgHUmL9Rh8xFuo9y72GH8c=
+          -----END RSA PRIVATE KEY-----
+        passphrase: password
+        certificate: |
+          -----BEGIN CERTIFICATE-----
+          MIID0DCCArgCCQDBRxU0ucjw6DANBgkqhkiG9w0BAQsFADCBqTELMAkGA1UEBhMC
+          VVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMR8wHQYDVQQK
+          ExZDbG91ZCBGb3VuZHJ5IElkZW50aXR5MQ4wDAYDVQQLEwVLZXkgMTEiMCAGA1UE
+          AxMZbG9naW4uaWRlbnRpdHkuY2YtYXBwLmNvbTEgMB4GCSqGSIb3DQEJARYRZmhh
+          bmlrQHBpdm90YWwuaW8wHhcNMTcwNDEwMTkxMTIyWhcNMTgwNDEwMTkxMTIyWjCB
+          qTELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1TYW4gRnJhbmNp
+          c2NvMR8wHQYDVQQKExZDbG91ZCBGb3VuZHJ5IElkZW50aXR5MQ4wDAYDVQQLEwVL
+          ZXkgMTEiMCAGA1UEAxMZbG9naW4uaWRlbnRpdHkuY2YtYXBwLmNvbTEgMB4GCSqG
+          SIb3DQEJARYRZmhhbmlrQHBpdm90YWwuaW8wggEiMA0GCSqGSIb3DQEBAQUAA4IB
+          DwAwggEKAoIBAQCtGS+R10tSg3K6+7SS2RwsvQLIYbwOuH2g+xpU4tUcmoHURuug
+          0xM9tjQc+O4PlYENlOLd+00unWY+f3AXLoWExO8hh5CZOyQfyb+TJVF5cb/N9apr
+          j5XpRbieZRy98Xdg2se83lU9NZMmtzYoHOx5ZDvQ5oE18GLrPhdt04Xjl0N9yTah
+          GdqyKdS/6sb49SXvHw6OB1XLJ6fqp4JDrG3xb18eD/83J2V/Bvf8v6zI+gG6N24d
+          qLsagtTOb/Oo4z12GVHmaO4QndBS+eYYqsYOh4cWiDQIyAsL4LRnhkA0HoZuOUxu
+          xBzOxpjEcyoAw6c57rEhdSs86hzutyXBl4cxAgMBAAEwDQYJKoZIhvcNAQELBQAD
+          ggEBAB72QKF9Iri+UdCGAIok/qIeKw5AwZ0wtiONa+DF4B80/yAA1ObpuO3eeeka
+          t0s4wtCRflE08zLrwqHlvKQAGKmJkfRLfEqfKStIUOTHQxE6wOaBtfW41M9ZF1hX
+          NHpnkfmSQjaHVNTRbABiFH6eTq8J6CuO12PyDf7lW3EofvcTU3ulsDhuMAz02ypJ
+          BgcOufnl+qP/m/BhVQsRD5mtJ56uJpHvri1VR2kj8N59V8f6KPO2m5Q6MulEhWml
+          TsxyxUl03oyICDP1cbpYtDk2VddVNWipHHPH/mBVW41EBVv0VDV03LH3RfS9dXiK
+          ynuP3shhqhFvaaiUTZP4l5yF/GQ=
+          -----END CERTIFICATE-----
+      key2:
+        key: |
+          -----BEGIN RSA PRIVATE KEY-----
+          MIIEpAIBAAKCAQEAwt7buITRZhXX98apcgJbiHhrPkrgn5MCsCphRQ89oWPUHWjN
+          j9Kz2m9LaKgq9DnNLl22U4e6/LUQToBCLxkIqwaobZKjIUjNAmNomqbNO7AD2+K7
+          RCiQ2qijWUwXGu+5+fSmF/MOermNKUDiQnRJSSSAPObAHOI980zTWVsApKpcFVaV
+          vk/299L/0rk8I/mNvf63cdw4Nh3xn4Ct+oCnTaDg5OtpGz8sHlocOAti+LdrtNzH
+          uBWq8q2sdhFQBRGe1MOeH8CAEHgKYwELTBCJEyLhykdRgxXJHSaL56+mb6HQvGO/
+          oyZHn+qHsCCjcdR1L/U4qt4m7HBimv0qbvApQwIDAQABAoIBAQCftmmcnHbG1WZR
+          NChSQa5ldlRnFJVvE90jJ0jbgfdAHAKQLAI2Ozme8JJ8bz/tNKZ+tt2lLlxJm9iG
+          jkYwNbNOAMHwNDuxHuqvZ2wnPEh+/+7Zu8VBwoGeRJLEsEFLmWjyfNnYTSPz37nb
+          Mst+LbKW2OylfXW89oxRqQibdqNbULpcU4NBDkMjToH1Z4dUFx3X2R2AAwgDz4Ku
+          HN4HoxbsbUCI5wLDJrTGrJgEntMSdsSdOY48YOMBnHqqfw7KoJ0sGjrPUy0vOGq2
+          CeP3uqbXX/mJpvJ+jg3Y2b1Zeu2I+vAnZrxlaZ+hYnZfoNqVjBZ/EEq/lmEovMvr
+          erP8FYI5AoGBAOrlmMZYdhW0fRzfpx6WiBJUkFfmit4qs9nQRCouv+jHS5QL9aM9
+          c+iKeP6kWuxBUYaDBmf5J1OBW4omNd384NX5PCiL/Fs/lxgdMZqEhnhT4Dj4Q6m6
+          ZXUuY6hamoF5+z2mtkZzRyvD1LUAARKJw6ggUtcH28cYC3RkZ5P6SWHVAoGBANRg
+          scI9pF2VUrmwpgIGhynLBEO26k8j/FyE3S7lPcUZdgPCUZB0/tGklSo183KT/KQY
+          TgO2mqb8a8xKCz41DTnUPqJWZzBOFw5QaD2i9O6soXUAKqaUm3g40/gyWX1hUtHa
+          K0Kw5z1Sf3MoCpW0Ozzn3znYbAoSvBRr53d0EVK3AoGAOD1ObbbCVwIGroIR1i3+
+          WD0s7g7Bkt2wf+bwWxUkV4xX2RNf9XyCItv8iiM5rbUZ2tXGE+DAfKrNCu+JGCQy
+          hKiOsbqKaiJ4f4qF1NQECg0y8xDlyl5Zakv4ClffBD77W1Bt9cIl+SGC7O8aUqDv
+          WnKawucbxLhKDcz4S6KyLR0CgYEAhuRrw24XqgEgLCVRK9QtoZP7P28838uBjNov
+          Cow8caY8WSLhX5mQCGQ7AjaGTG5Gd4ugcadYD1wgs/8LqRVVMzfmGII8xGe1KThV
+          HWEVpUssuf3DGU8meHPP3sNMJ+DbE8M42wE1vrNZlDEImBGD1qmIFVurM7K2l1n6
+          CNtF7X0CgYBuFf0A0cna8LnxOAPm8EPHgFq4TnDU7BJzzcO/nsORDcrh+dZyGJNS
+          fUTMp4k+AQCm9UwJAiSf4VUwCbhXUZ3S+xB55vrH+Yc2OMtsIYhzr3OCkbgKBMDn
+          nBVKSGAomYD2kCUmSbg7bUrFfGntmvOLqTHtVfrCyE5i8qS63RbHlA==
+          -----END RSA PRIVATE KEY-----
+        passphrase: password
+        certificate: |
+          -----BEGIN CERTIFICATE-----
+          MIID0DCCArgCCQDqnPTUvA17+TANBgkqhkiG9w0BAQsFADCBqTELMAkGA1UEBhMC
+          VVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMR8wHQYDVQQK
+          ExZDbG91ZCBGb3VuZHJ5IElkZW50aXR5MQ4wDAYDVQQLEwVLZXkgMjEiMCAGA1UE
+          AxMZbG9naW4uaWRlbnRpdHkuY2YtYXBwLmNvbTEgMB4GCSqGSIb3DQEJARYRZmhh
+          bmlrQHBpdm90YWwuaW8wHhcNMTcwNDEwMTkxNTAyWhcNMTgwNDEwMTkxNTAyWjCB
+          qTELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1TYW4gRnJhbmNp
+          c2NvMR8wHQYDVQQKExZDbG91ZCBGb3VuZHJ5IElkZW50aXR5MQ4wDAYDVQQLEwVL
+          ZXkgMjEiMCAGA1UEAxMZbG9naW4uaWRlbnRpdHkuY2YtYXBwLmNvbTEgMB4GCSqG
+          SIb3DQEJARYRZmhhbmlrQHBpdm90YWwuaW8wggEiMA0GCSqGSIb3DQEBAQUAA4IB
+          DwAwggEKAoIBAQDC3tu4hNFmFdf3xqlyAluIeGs+SuCfkwKwKmFFDz2hY9QdaM2P
+          0rPab0toqCr0Oc0uXbZTh7r8tRBOgEIvGQirBqhtkqMhSM0CY2iaps07sAPb4rtE
+          KJDaqKNZTBca77n59KYX8w56uY0pQOJCdElJJIA85sAc4j3zTNNZWwCkqlwVVpW+
+          T/b30v/SuTwj+Y29/rdx3Dg2HfGfgK36gKdNoODk62kbPyweWhw4C2L4t2u03Me4
+          Faryrax2EVAFEZ7Uw54fwIAQeApjAQtMEIkTIuHKR1GDFckdJovnr6ZvodC8Y7+j
+          Jkef6oewIKNx1HUv9Tiq3ibscGKa/Spu8ClDAgMBAAEwDQYJKoZIhvcNAQELBQAD
+          ggEBAKzeh/bRDEEP/WGsiYhCCfvESyt0QeKwUk+Hfl0/oP4m9pXNrnMRApyoi7FB
+          owpmXIeqDqGigPai6pJ3xCO94P+Bz7WTk0+jScYm/hGpcIOeKh8FBfW0Fddu9Otn
+          qVk0FdRSCTjUZKQlNOqVTjBeKOjHmTkgh96IR3EP2/hp8Ym4HLC+w265V7LnkqD2
+          SoMez7b2V4NmN7z9OxTALUbTzmFG77bBDExHvfbiFlkIptx8+IloJOCzUsPEg6Ur
+          kueuR7IB1S4q6Ja7Gb9b9NYQDFt4hjb5mC9aPxaX+KK2JlZg4cTFVCdkIyp2/fHI
+          iQpMzNWb7zZWlCfDL4dJZHYoNfg=
+          -----END CERTIFICATE-----
+
+    socket:
+      connectionManagerTimeout: 10000
+      soTimeout: 10000
+    signMetaData: true
+    signRequest: true
+    wantAssertionSigned: true
+    disableInResponseToCheck: true
+    providers:
+      my-identity-provider:
+        metadataTrustCheck: false
+        nameID: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+        assertionConsumerIndex: 0
+        signMetaData: false
+        signRequest: false
+        iconUrl: https://my.identityprovider.com/icon.png
+        showSamlLoginLink: true
+        linkText: Log in with My Saml Identity Provider
+        groupMappingMode: AS_SCOPES
+        idpMetadata: http://my.identityprovider.com/saml2/idp/metadata.php
+        skipSslValidation: false
+      CA_SM1:
+        override: false
+        assertionConsumerIndex: 0
+        attributeMappings:
+          email: mail
+        emailDomain:
+        - casecurecenter.com
+        linkText: SiteMinder
+        metadataTrustCheck: false
+        nameID: urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
+        showSamlLoginLink: true
+        signMetaData: false
+        signRequest: false
+        storeCustomAttributes: false
+        idpMetadata: |
+          <EntityDescriptor ID="SM1598b525eada26863eb23b38177f5bc861b48bf93309" entityID="smidp" xmlns="urn:oasis:names:tc:SAML:2.0:metadata">
+                <IDPSSODescriptor ID="SM213f05e6446b0930163464f8875298c3b5ed62a2f9b" WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+                      <KeyDescriptor use="signing">
+                            <ns1:KeyInfo Id="SM1371f007ef6afdd435cd105782eff7a275ee57c45d6" xmlns:ns1="http://www.w3.org/2000/09/xmldsig#">
+                                  <ns1:X509Data>
+                                        <ns1:X509IssuerSerial>
+                                              <ns1:X509IssuerName>CN=siteminder,OU=security,O=ca,L=islandia,ST=new york,C=US</ns1:X509IssuerName>
+                                              <ns1:X509SerialNumber>1389887106</ns1:X509SerialNumber>
+                                        </ns1:X509IssuerSerial>
+                                        <ns1:X509Certificate>MIICRzCCAbCgAwIBAgIEUtf+gjANBgkqhkiG9w0BAQQFADBoMQswCQYDVQQGEwJVUzERMA8GA1UECBMIbmV3IHlvcmsxETAPBgNVBAcTCGlzbGFuZGlhMQswCQYDVQQKEwJjYTERMA8GA1UECxMIc2VjdXJpdHkxEzARBgNVBAMTCnNpdGVtaW5kZXIwHhcNMTQwMTE2MTU0NTA2WhcNMjQwMTE0MTU0NTA2WjBoMQswCQYDVQQGEwJVUzERMA8GA1UECBMIbmV3IHlvcmsxETAPBgNVBAcTCGlzbGFuZGlhMQswCQYDVQQKEwJjYTERMA8GA1UECxMIc2VjdXJpdHkxEzARBgNVBAMTCnNpdGVtaW5kZXIwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAOap0m7c+LSOAoGLUD3TAdS7BcJFns6HPSGAYK9NBY6MxITKElqVWHaVoaqxHCQxdQsF9oZvhPAmiNsbIRniKA+cypUov8U0pNIRPPBfl7p9ojGPZf5OtotnUnEN2ZcYuZwxRnKPfpfEs5fshSvcZIa34FCSCw8L0sRDoWFIucBjAgMBAAEwDQYJKoZIhvcNAQEEBQADgYEAFbsuhxBm3lUkycfZZuNYft1j41k+FyLLTyXyPJKmc2s2RPOYtLQyolNB214ZCIZzVSExyfo959ZBvdWz+UinpFNPd8cEc0nuXOmfW/XBEgT0YS1vIDUzfeVRyZLj2u4BdBGwmK5oYRbgHxViFVnn3C6UN5rcg5mZl0FBXJ31Zuk=</ns1:X509Certificate>
+                                        <ns1:X509SubjectName>CN=siteminder,OU=security,O=ca,L=islandia,ST=new york,C=US</ns1:X509SubjectName>
+                                  </ns1:X509Data>
+                            </ns1:KeyInfo>
+                      </KeyDescriptor>
+                      <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+                      <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://vp6.casecurecenter.com/affwebservices/public/saml2sso"/>
+                      <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://vp6.casecurecenter.com/affwebservices/public/saml2sso"/>
+                </IDPSSODescriptor>
+          </EntityDescriptor>
+      okta-preview:
+        metadataTrustCheck: false
+        nameID: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+        signMetaData: false
+        signRequest: false
+        idpMetadata: |
+          <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="http://www.okta.com/k2lw4l5bPODCMIIDBRYZ"><md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIICmTCCAgKgAwIBAgIGAUPATqmEMA0GCSqGSIb3DQEBBQUAMIGPMQswCQYDVQQGEwJVUzETMBEG
+          A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+          MBIGA1UECwwLU1NPUHJvdmlkZXIxEDAOBgNVBAMMB1Bpdm90YWwxHDAaBgkqhkiG9w0BCQEWDWlu
+          Zm9Ab2t0YS5jb20wHhcNMTQwMTIzMTgxMjM3WhcNNDQwMTIzMTgxMzM3WjCBjzELMAkGA1UEBhMC
+          VVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xDTALBgNVBAoM
+          BE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMRAwDgYDVQQDDAdQaXZvdGFsMRwwGgYJKoZIhvcN
+          AQkBFg1pbmZvQG9rdGEuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCeil67/TLOiTZU
+          WWgW2XEGgFZ94bVO90v5J1XmcHMwL8v5Z/8qjdZLpGdwI7Ph0CyXMMNklpaR/Ljb8fsls3amdT5O
+          Bw92Zo8ulcpjw2wuezTwL0eC0wY/GQDAZiXL59npE6U+fH1lbJIq92hx0HJSru/0O1q3+A/+jjZL
+          3tL/SwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAI5BoWZoH6Mz9vhypZPOJCEKa/K+biZQsA4Zqsuk
+          vvphhSERhqk/Nv76Vkl8uvJwwHbQrR9KJx4L3PRkGCG24rix71jEuXVGZUsDNM3CUKnARx4MEab6
+          GFHNkZ6DmoT/PFagngecHu+EwmuDtaG0rEkFrARwe+d8Ru0BN558abFb</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://pivotal.oktapreview.com/app/pivotal_pivotalcfstaging_1/k2lw4l5bPODCMIIDBRYZ/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://pivotal.oktapreview.com/app/pivotal_pivotalcfstaging_1/k2lw4l5bPODCMIIDBRYZ/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+      simplesamlphp-url:
+        assertionConsumerIndex: 0
+        attributeMappings:
+          user.attribute.employeeCostCenter: costCenter
+          user.attribute.terribleBosses: manager
+        linkText: Log in with Simple SAML PHP URL
+        metadataTrustCheck: false
+        nameID: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+        showSamlLoginLink: true
+        signMetaData: false
+        signRequest: false
+        skipSslValidation: true
+        idpMetadata: http://simplesamlphp.identity.cf-app.com/saml2/idp/metadata.php
+  branding:
+    companyName: company name
+    productLogo: |
+      base 64 with line feeds
+      for product logo
+    squareLogo: |
+      base 64 with line feeds
+      for square logo
+    footerLegalText: Legal text
+    footerLinks:
+      terms of service: http://terms.of.service/
+    banner:
+      logo: |
+        base 64 with line feeds
+        for banner logo
+      text: banner text
+      textColor: "#AABBCC"
+      backgroundColor: "#DDEEFF"
+      link: http://www.example.com
+    consent:
+      text: Terms and Conditions
+      link: http://www.example.com
+  serviceProviderKeyPassword: ""
+  serviceProviderCertificate: |
+    -----BEGIN CERTIFICATE-----
+    MIIEJTCCA46gAwIBAgIJANIqfxWTfhpkMA0GCSqGSIb3DQEBBQUAMIG+MQswCQYD
+    VQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZyYW5j
+    aXNjbzEdMBsGA1UEChMUUGl2b3RhbCBTb2Z0d2FyZSBJbmMxJDAiBgNVBAsTG0Ns
+    b3VkIEZvdW5kcnkgSWRlbnRpdHkgVGVhbTEcMBoGA1UEAxMTaWRlbnRpdHkuY2Yt
+    YXBwLmNvbTEfMB0GCSqGSIb3DQEJARYQbWFyaXNzYUB0ZXN0Lm9yZzAeFw0xNTA1
+    MTQxNzE5MTBaFw0yNTA1MTExNzE5MTBaMIG+MQswCQYDVQQGEwJVUzETMBEGA1UE
+    CBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZyYW5jaXNjbzEdMBsGA1UEChMU
+    UGl2b3RhbCBTb2Z0d2FyZSBJbmMxJDAiBgNVBAsTG0Nsb3VkIEZvdW5kcnkgSWRl
+    bnRpdHkgVGVhbTEcMBoGA1UEAxMTaWRlbnRpdHkuY2YtYXBwLmNvbTEfMB0GCSqG
+    SIb3DQEJARYQbWFyaXNzYUB0ZXN0Lm9yZzCBnzANBgkqhkiG9w0BAQEFAAOBjQAw
+    gYkCgYEA30y2nX+kICXktl1yJhBzLGvtTuzJiLeOMWi++zdivifyRqX1dwJ5MgdO
+    sBWdNrASwe4ZKONiyLFRDsk7lAYq3f975chxSsrRu1BLetBZfPEmwBH7FCTdYtWk
+    lJbpz0vzQs/gSsMChT/UrN6zSJhPVHNizLxstedyxxVVts644U8CAwEAAaOCAScw
+    ggEjMB0GA1UdDgQWBBSvWY/TyHysYGxKvII95wD/CzE1AzCB8wYDVR0jBIHrMIHo
+    gBSvWY/TyHysYGxKvII95wD/CzE1A6GBxKSBwTCBvjELMAkGA1UEBhMCVVMxEzAR
+    BgNVBAgTCkNhbGlmb3JuaWExFjAUBgNVBAcTDVNhbiBGcmFuY2lzY28xHTAbBgNV
+    BAoTFFBpdm90YWwgU29mdHdhcmUgSW5jMSQwIgYDVQQLExtDbG91ZCBGb3VuZHJ5
+    IElkZW50aXR5IFRlYW0xHDAaBgNVBAMTE2lkZW50aXR5LmNmLWFwcC5jb20xHzAd
+    BgkqhkiG9w0BCQEWEG1hcmlzc2FAdGVzdC5vcmeCCQDSKn8Vk34aZDAMBgNVHRME
+    BTADAQH/MA0GCSqGSIb3DQEBBQUAA4GBAL5j1JCN5EoXMOOBSBUL8KeVZFQD3Nfy
+    YkYKBatFEKdBFlAKLBdG+5KzE7sTYesn7EzBISHXFz3DhdK2tg+IF1DeSFVmFl2n
+    iVxQ1sYjo4kCugHBsWo+MpFH9VBLFzsMlP3eIDuVKe8aPXFKYCGhctZEJdQTKlja
+    lshe50nayKrT
+    -----END CERTIFICATE-----
+  serviceProviderKey: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIICXgIBAAKBgQDfTLadf6QgJeS2XXImEHMsa+1O7MmIt44xaL77N2K+J/JGpfV3
+    AnkyB06wFZ02sBLB7hko42LIsVEOyTuUBird/3vlyHFKytG7UEt60Fl88SbAEfsU
+    JN1i1aSUlunPS/NCz+BKwwKFP9Ss3rNImE9Uc2LMvGy153LHFVW2zrjhTwIDAQAB
+    AoGBAJDh21LRcJITRBQ3CUs9PR1DYZPl+tUkE7RnPBMPWpf6ny3LnDp9dllJeHqz
+    a3ACSgleDSEEeCGzOt6XHnrqjYCKa42Z+Opnjx/OOpjyX1NAaswRtnb039jwv4gb
+    RlwT49Y17UAQpISOo7JFadCBoMG0ix8xr4ScY+zCSoG5v0BhAkEA8llNsiWBJF5r
+    LWQ6uimfdU2y1IPlkcGAvjekYDkdkHiRie725Dn4qRiXyABeaqNm2bpnD620Okwr
+    sf7LY+BMdwJBAOvgt/ZGwJrMOe/cHhbujtjBK/1CumJ4n2r5V1zPBFfLNXiKnpJ6
+    J/sRwmjgg4u3Anu1ENF3YsxYabflBnvOP+kCQCQ8VBCp6OhOMcpErT8+j/gTGQUL
+    f5zOiPhoC2zTvWbnkCNGlqXDQTnPUop1+6gILI2rgFNozoTU9MeVaEXTuLsCQQDC
+    AGuNpReYucwVGYet+LuITyjs/krp3qfPhhByhtndk4cBA5H0i4ACodKyC6Zl7Tmf
+    oYaZoYWi6DzbQQUaIsKxAkEA2rXQjQFsfnSm+w/9067ChWg46p4lq5Na2NpcpFgH
+    waZKhM1W0oB8MX78M+0fG3xGUtywTx0D4N7pr1Tk2GTgNw==
+    -----END RSA PRIVATE KEY-----
+  selfServiceLinksEnabled: false
+  oauth:
+    externalGroupsFromMappedAuthorities: true
+    providers:
+      my-oauth-provider:
+        override: false
+        type: oidc1.0
+        authUrl: http://authUrl
+        tokenUrl: http://tokenUrl
+        tokenKey: |
+          token key
+          encoded value
+          here
+        tokenKeyUrl: http://tokenKeyUrl
+        cacheJwks: true
+        pkce: true
+        authMethod: client_secret_basic
+        additionalAuthzParameters:
+          - token_format: jwt
+        issuer: http://tokenUrl
+        scopes:
+        - openid
+        linkText: My Oauth Provider
+        showLinkText: true
+        addShadowUserOnLogin: true
+        relyingPartyId: "<OIDC Client ID>"
+        relyingPartySecret: "<OIDC Client secret>"
+        skipSslValidation: false
+        storeCustomAttributes: false
+        passwordGrantEnabled: false
+        performRpInitiatedLogout: true
+        prompts:
+          - name: username
+            type: text
+            text: Email
+          - name: password
+            type: password
+            text: Password
+          - name: passcode
+            type: password
+            text: Temporary Authentication Code (Get on at /passcode)
+        jwtClientAuthentication:
+          kid: key-2
+        attributeMappings:
+          given_name: first_name
+          family_name: last_name
+          user_name: username
+          external_groups:
+          - group1
+          - group2
+          user.attribute.name-of-attribute-in-uaa-id-token: name-of-attribute-in-provider-token
+          user.attribute.name-of-other-attribute-in-uaa-id-token: name-of-other-attribute-in-provider-token
+
+servlet:
+  session-store: memory
+  idle-timeout: 300
+  session-cookie:
+    max-age: 1800
+    encode-base64: false
+
+smtp:
+  host: smtp_host
+  port: 25
+  auth: true
+  starttls: true
+  user: smtp_user
+  password: smtp_password
+  from_address: from@from.com
+  sslprotocols: TLSv1.2
+notifications:
+  url: http://notifications
+
+rest:
+  template:
+    timeout: 10000
+    maxTotal: 20
+    maxPerRoute: 2
+    maxKeepAlive: 0
+    validateAfterInactivity: 2000
+    retryCount: 0
+
+ratelimit:
+  loggingOption: AllCalls
+  credentialID: 'JWT:Claims+"sub"\s*:\s*"(.*?)"'
+  limiterMappings:
+    - name: AuthToken
+      withCallerRemoteAddressID: 50r/s
+      pathSelectors:
+        - "equals:/oauth/token"
+    - name: EverythingElse
+      global: 200r/s
+      pathSelectors:
+        - "other"
+
+global:
+  jwk:
+    oidc-trust:
+      key: "key-value"
+      cert: "cert-value"
+    uaa:
+      key: "uaa-zone-key-value"
+      cert: "uaa-zone-cert-value"

--- a/spec/compare/bosh-lite-log4j2-defaults.properties
+++ b/spec/compare/bosh-lite-log4j2-defaults.properties
@@ -1,0 +1,85 @@
+status = error
+dest = err
+name = UaaLog
+
+property.log_directory = /var/vcap/sys/log/uaa
+property.log_pattern=[%d{yyyy-MM-dd'T'HH:mm:ss.nnnnnn}{GMT+0}Z] uaa%X{context} - %pid [%t] - [%X{traceId},%X{spanId}] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=|code=|access_token=|refresh_token=|id_token=)([^&\s]*)}{<redacted>}%n
+
+appender.uaaDefaultAppender.type = File
+appender.uaaDefaultAppender.name = UaaDefaultAppender
+appender.uaaDefaultAppender.fileName = ${log_directory}/uaa.log
+appender.uaaDefaultAppender.layout.type = PatternLayout
+appender.uaaDefaultAppender.layout.pattern = ${log_pattern}
+
+appender.uaaAuditAppender.type = File
+appender.uaaAuditAppender.name = UaaAuditAppender
+appender.uaaAuditAppender.fileName = ${log_directory}/uaa_events.log
+appender.uaaAuditAppender.layout.type = PatternLayout
+appender.uaaAuditAppender.layout.pattern = ${log_pattern}
+
+rootLogger.level = info
+rootLogger.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.UAAAudit.name = UAA.Audit
+logger.UAAAudit.level = info
+logger.UAAAudit.additivity = true
+logger.UAAAudit.appenderRef.auditEventLog.ref = UaaAuditAppender
+
+
+# These loggers have a configurable level
+logger.cfIdentity.name = org.cloudfoundry.identity
+logger.cfIdentity.level = INFO
+logger.cfIdentity.additivity = false
+logger.cfIdentity.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springSecurity.name = org.springframework.security
+logger.springSecurity.level = INFO
+logger.springSecurity.additivity = false
+logger.springSecurity.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springJdbc.name = org.springframework.jdbc
+logger.springJdbc.level = INFO
+logger.springJdbc.additivity = false
+logger.springJdbc.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+
+# These loggers have a fixed level of "info"
+logger.springWebStandardServletEnvironment.name = org.springframework.web.context.support.StandardServletEnvironment
+logger.springWebStandardServletEnvironment.level = info
+logger.springWebStandardServletEnvironment.additivity = false
+logger.springWebStandardServletEnvironment.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.apacheHttpWire.name = org.apache.http.wire
+logger.apacheHttpWire.level = info
+logger.apacheHttpWire.additivity = false
+logger.apacheHttpWire.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springAopAspectJExpressionPointcut.name = org.springframework.aop.aspectj.AspectJExpressionPointcut
+logger.springAopAspectJExpressionPointcut.level = info
+logger.springAopAspectJExpressionPointcut.additivity = false
+logger.springAopAspectJExpressionPointcut.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springBeansDefaultListableBeanFactory.name = org.springframework.beans.factory.support.DefaultListableBeanFactory
+logger.springBeansDefaultListableBeanFactory.level = info
+logger.springBeansDefaultListableBeanFactory.additivity = false
+logger.springBeansDefaultListableBeanFactory.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springBeansDisposableBeanAdaptor.name = org.springframework.beans.factory.support.DisposableBeanAdapter
+logger.springBeansDisposableBeanAdaptor.level = info
+logger.springBeansDisposableBeanAdaptor.additivity = false
+logger.springBeansDisposableBeanAdaptor.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springSecurityLdapAuthenticationProvider.name = org.springframework.security.ldap.authentication.LdapAuthenticationProvider
+logger.springSecurityLdapAuthenticationProvider.level = info
+logger.springSecurityLdapAuthenticationProvider.additivity = false
+logger.springSecurityLdapAuthenticationProvider.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springSecurityFilterBasedUserSearch.name = org.springframework.security.ldap.search.FilterBasedLdapUserSearch
+logger.springSecurityFilterBasedUserSearch.level = info
+logger.springSecurityFilterBasedUserSearch.additivity = false
+logger.springSecurityFilterBasedUserSearch.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springWeb.name = org.springframework.web
+logger.springWeb.level = info
+logger.springWeb.additivity = false
+logger.springWeb.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender

--- a/spec/compare/bosh-lite-uaa-defaults.yml
+++ b/spec/compare/bosh-lite-uaa-defaults.yml
@@ -1,0 +1,394 @@
+---
+name: uaa
+
+encryption:
+  active_key_label: key1
+  encryption_keys:
+  - label: key1
+    passphrase: my-passphrase
+
+database:
+  url: jdbc:postgresql://10.244.0.30:5524/uaadb?sslmode=verify-full&sslfactory=org.postgresql.ssl.DefaultJavaSSLFactory
+  username: uaaadmin
+  password: "admin"
+  maxactive: 100
+  maxidle:  10
+  minidle:  0
+  removeabandoned: false
+  logabandoned: true
+  abandonedtimeout: 300
+  testwhileidle: false
+
+
+spring_profiles: postgresql
+
+logging:
+  config: /var/vcap/jobs/uaa/config/log4j2.properties
+
+jwt:
+  token:
+    queryString:
+      enabled: true
+    revocable: false
+    policy:
+      accessTokenValiditySeconds:  43200
+      refreshTokenValiditySeconds: 2592000
+      global:
+        accessTokenValiditySeconds: 43200
+        refreshTokenValiditySeconds: 2592000
+    signing-key: |
+        -----BEGIN RSA PRIVATE KEY-----
+        MIICXAIBAAKBgQDHFr+KICms+tuT1OXJwhCUmR2dKVy7psa8xzElSyzqx7oJyfJ1
+        JZyOzToj9T5SfTIq396agbHJWVfYphNahvZ/7uMXqHxf+ZH9BL1gk9Y6kCnbM5R6
+        0gfwjyW1/dQPjOzn9N394zd2FJoFHwdq9Qs0wBugspULZVNRxq7veq/fzwIDAQAB
+        AoGBAJ8dRTQFhIllbHx4GLbpTQsWXJ6w4hZvskJKCLM/o8R4n+0W45pQ1xEiYKdA
+        Z/DRcnjltylRImBD8XuLL8iYOQSZXNMb1h3g5/UGbUXLmCgQLOUUlnYt34QOQm+0
+        KvUqfMSFBbKMsYBAoQmNdTHBaz3dZa8ON9hh/f5TT8u0OWNRAkEA5opzsIXv+52J
+        duc1VGyX3SwlxiE2dStW8wZqGiuLH142n6MKnkLU4ctNLiclw6BZePXFZYIK+AkE
+        xQ+k16je5QJBAN0TIKMPWIbbHVr5rkdUqOyezlFFWYOwnMmw/BKa1d3zp54VP/P8
+        +5aQ2d4sMoKEOfdWH7UqMe3FszfYFvSu5KMCQFMYeFaaEEP7Jn8rGzfQ5HQd44ek
+        lQJqmq6CE2BXbY/i34FuvPcKU70HEEygY6Y9d8J3o6zQ0K9SYNu+pcXt4lkCQA3h
+        jJQQe5uEGJTExqed7jllQ0khFJzLMx0K6tj0NeeIzAaGCQz13oo2sCdeGRHO4aDh
+        HH6Qlq/6UOV5wP8+GAcCQFgRCcB+hrje8hfEEefHcFpyKH+5g1Eu1k0mLrxK2zd+
+        4SlotYRHgPCEubokb2S1zfZDWIXW3HmggnGgM949TlY=
+        -----END RSA PRIVATE KEY-----
+    verification-key: |
+        -----BEGIN PUBLIC KEY-----
+        MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDHFr+KICms+tuT1OXJwhCUmR2d
+        KVy7psa8xzElSyzqx7oJyfJ1JZyOzToj9T5SfTIq396agbHJWVfYphNahvZ/7uMX
+        qHxf+ZH9BL1gk9Y6kCnbM5R60gfwjyW1/dQPjOzn9N394zd2FJoFHwdq9Qs0wBug
+        spULZVNRxq7veq/fzwIDAQAB
+        -----END PUBLIC KEY-----
+    refresh:
+      restrict_grant: false
+      unique: false
+      rotate: false
+      format: jwt
+
+authentication:
+  enableUriEncodingCompatibilityMode: false
+  policy:
+    lockoutAfterFailures: 5
+    countFailuresWithinSeconds: 1200
+    lockoutPeriodSeconds: 300
+    global:
+      lockoutAfterFailures: 5
+      countFailuresWithinSeconds: 3600
+      lockoutPeriodSeconds: 300
+
+password:
+  policy:
+    minLength: 0
+    maxLength: 255
+    requireUpperCaseCharacter: 0
+    requireLowerCaseCharacter: 0
+    requireDigit: 0
+    requireSpecialCharacter: 0
+    expirePasswordInMonths: 0
+    global:
+      minLength: 0
+      maxLength: 255
+      requireUpperCaseCharacter: 0
+      requireLowerCaseCharacter: 0
+      requireDigit: 0
+      requireSpecialCharacter: 0
+      expirePasswordInMonths: 0
+
+disableInternalAuth: false
+disableInternalUserManagement: false
+
+issuer:
+  uri: https://uaa.bosh-lite.com
+
+oauth:
+  authorize:
+    ssl: true
+  clients:
+    cc-service-dashboards:
+      id: cc-service-dashboards
+      authorities: clients.read,clients.write,clients.admin
+      authorized-grant-types: client_credentials
+      scope: openid,cloud_controller_service_permissions.read
+      secret: cc-broker-secret
+    cc_routing:
+      id: cc_routing
+      authorities: routing.router_groups.read
+      authorized-grant-types: client_credentials
+      secret: cc-routing-secret
+    cf:
+      id: cf
+      secret: ''
+      access-token-validity: 600
+      authorities: uaa.none
+      authorized-grant-types: password,refresh_token
+      override: true
+      refresh-token-validity: 2592000
+      scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read
+    cloud_controller_username_lookup:
+      id: cloud_controller_username_lookup
+      authorities: scim.userids
+      authorized-grant-types: client_credentials
+      secret: cloud-controller-username-lookup-secret
+    doppler:
+      id: doppler
+      authorities: uaa.resource
+      override: true
+      secret: doppler-secret
+      authorized-grant-types: client_credentials
+    gorouter:
+      id: gorouter
+      authorities: routing.routes.read
+      authorized-grant-types: client_credentials
+      secret: gorouter-secret
+    notifications:
+      id: notifications
+      authorities: cloud_controller.admin,scim.read
+      authorized-grant-types: client_credentials
+      secret: notification-secret
+    ssh-proxy:
+      id: ssh-proxy
+      authorized-grant-types: authorization_code
+      autoapprove: true
+      override: true
+      redirect-uri: http://ssh-proxy-redirect-domain.com/login
+      scope: openid,cloud_controller.read,cloud_controller.write,cloud_controller.admin
+      secret: ssh-proxy-secret
+    tcp_emitter:
+      id: tcp_emitter
+      authorities: routing.routes.write,routing.routes.read,routing.router_groups.read
+      authorized-grant-types: client_credentials
+      secret: tcp-emitter-secret
+    tcp_router:
+      id: tcp_router
+      authorities: routing.routes.read,routing.router_groups.read
+      authorized-grant-types: client_credentials
+      secret: tcp-router-secret
+    admin:
+      authorized-grant-types: client_credentials
+      authorities: clients.read,clients.write,clients.secret,uaa.admin,scim.read,scim.write,password.write
+      id: admin
+      secret: "admin-secret"
+    implicit_ok:
+      id: implicit_ok
+      scope: openid
+      authorized-grant-types: implicit
+      secret: null
+      redirect-uri: "http://some.redirect.com/callback"
+    many_redirects:
+      id: many_redirects
+      scope: uaa.user
+      authorized-grant-types: authorization_code
+      secret: secret
+      redirect-uri: http://localhost,http://localhost:8080,http://localhost:8080/uaa,http://valid.cloudfoundry.org,http://sub.valid.cloudfoundry.org,http://valid.cloudfoundry.org/with/path,https://subsub.sub.valid.cloudfoundry.org/**,https://valid.cloudfoundry.org/path/*/path,http://sub.valid.cloudfoundry.org/*/with/path**,http*://sub.valid.cloudfoundry.org/*/with/path**,http*://*.valid.cloudfoundry.org/*/with/path**,http://*.valid.cloudfoundry.org/*/with/path**,https://*.valid.cloudfoundry.org/*/with/path**,https://*.*.valid.cloudfoundry.org/*/with/path**,http://sub*.valid.cloudfoundry.org/*/with/path**,http://*.domain.com,http://username:password@some.server.com,http://username:password@some.server.com/path
+
+  user:
+    authorities:
+      - openid
+      - scim.me
+      - cloud_controller.read
+      - cloud_controller.write
+      - cloud_controller_service_permissions.read
+      - password.write
+      - uaa.user
+      - approvals.me
+      - oauth.approvals
+      - notification_preferences.read
+      - notification_preferences.write
+      - profile
+      - roles
+      - user_attributes
+      - uaa.offline_token
+scim:
+  userids_enabled: true
+  user:
+    override: true
+  users:
+    - admin|admin|admin|||scim.write,scim.read,openid,cloud_controller.admin,clients.read,clients.write,doppler.firehose,routing.router_groups.read|uaa
+
+zones:
+  internal:
+    hostnames:
+      - uaa.service.cf.internal
+
+require_https: true
+https_port: 8443
+
+uaa:
+  url: https://uaa.bosh-lite.com
+  limitedFunctionality:
+    statusFile: /var/vcap/data/uaa/bbr_limited_mode.lock
+    whitelist:
+      endpoints:
+      - /oauth/authorize/**
+      - /oauth/token/**
+      - /check_token/**
+      methods:
+      - GET
+      - HEAD
+  shutdown:
+    sleep: 5000
+  oauth:
+    redirect_uri:
+      allow_unsafe_matching: false
+
+links:
+  global:
+    passwd: /forgot_password
+    signup: /create_account
+    homeRedirect: '/'
+  homeRedirect: '/'
+  passwd: https://login.bosh-lite.com/forgot_password
+  signup: https://login.bosh-lite.com/create_account
+
+smtp:
+  host: localhost
+  password:
+  port: 2525
+  user:
+  from_address:
+  auth: false
+  starttls: false
+  sslprotocols: TLSv1.2
+
+assetBaseUrl: /resources/oss
+
+logout:
+  redirect:
+    url: /login
+    parameter:
+      disable: false
+
+login:
+  url: https://login.bosh-lite.com
+  selfServiceLinksEnabled: true
+  defaultIdentityProvider: uaa
+  idpDiscoveryEnabled: false
+  accountChooserEnabled: false
+  aliasEntitiesEnabled: false
+  checkOriginEnabled: false
+  allowOriginLoop: true
+  entityBaseURL: https://login.bosh-lite.com
+  entityID: login.bosh-lite.com
+  prompt:
+    username:
+      text: Email
+    password:
+      text: Password
+  serviceProviderKey: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIICXQIBAAKBgQDHtC5gUXxBKpEqZTLkNvFwNGnNIkggNOwOQVNbpO0WVHIivig5
+    L39WqS9u0hnA+O7MCA/KlrAR4bXaeVVhwfUPYBKIpaaTWFQR5cTR1UFZJL/OF9vA
+    fpOwznoD66DDCnQVpbCjtDYWX+x6imxn8HCYxhMol6ZnTbSsFW6VZjFMjQIDAQAB
+    AoGAVOj2Yvuigi6wJD99AO2fgF64sYCm/BKkX3dFEw0vxTPIh58kiRP554Xt5ges
+    7ZCqL9QpqrChUikO4kJ+nB8Uq2AvaZHbpCEUmbip06IlgdA440o0r0CPo1mgNxGu
+    lhiWRN43Lruzfh9qKPhleg2dvyFGQxy5Gk6KW/t8IS4x4r0CQQD/dceBA+Ndj3Xp
+    ubHfxqNz4GTOxndc/AXAowPGpge2zpgIc7f50t8OHhG6XhsfJ0wyQEEvodDhZPYX
+    kKBnXNHzAkEAyCA76vAwuxqAd3MObhiebniAU3SnPf2u4fdL1EOm92dyFs1JxyyL
+    gu/DsjPjx6tRtn4YAalxCzmAMXFSb1qHfwJBAM3qx3z0gGKbUEWtPHcP7BNsrnWK
+    vw6By7VC8bk/ffpaP2yYspS66Le9fzbFwoDzMVVUO/dELVZyBnhqSRHoXQcCQQCe
+    A2WL8S5o7Vn19rC0GVgu3ZJlUrwiZEVLQdlrticFPXaFrn3Md82ICww3jmURaKHS
+    N+l4lnMda79eSp3OMmq9AkA0p79BvYsLshUJJnvbk76pCjR28PK4dV1gSDUEqQMB
+    qy45ptdwJLqLJCeNoR0JUcDNIRhOCuOPND7pcMtX6hI/
+    -----END RSA PRIVATE KEY-----
+  serviceProviderKeyPassword: password
+  serviceProviderCertificate: |
+    -----BEGIN CERTIFICATE-----
+    MIIDSTCCArKgAwIBAgIBADANBgkqhkiG9w0BAQQFADB8MQswCQYDVQQGEwJhdzEO
+    MAwGA1UECBMFYXJ1YmExDjAMBgNVBAoTBWFydWJhMQ4wDAYDVQQHEwVhcnViYTEO
+    MAwGA1UECxMFYXJ1YmExDjAMBgNVBAMTBWFydWJhMR0wGwYJKoZIhvcNAQkBFg5h
+    cnViYUBhcnViYS5hcjAeFw0xNTExMjAyMjI2MjdaFw0xNjExMTkyMjI2MjdaMHwx
+    CzAJBgNVBAYTAmF3MQ4wDAYDVQQIEwVhcnViYTEOMAwGA1UEChMFYXJ1YmExDjAM
+    BgNVBAcTBWFydWJhMQ4wDAYDVQQLEwVhcnViYTEOMAwGA1UEAxMFYXJ1YmExHTAb
+    BgkqhkiG9w0BCQEWDmFydWJhQGFydWJhLmFyMIGfMA0GCSqGSIb3DQEBAQUAA4GN
+    ADCBiQKBgQDHtC5gUXxBKpEqZTLkNvFwNGnNIkggNOwOQVNbpO0WVHIivig5L39W
+    qS9u0hnA+O7MCA/KlrAR4bXaeVVhwfUPYBKIpaaTWFQR5cTR1UFZJL/OF9vAfpOw
+    znoD66DDCnQVpbCjtDYWX+x6imxn8HCYxhMol6ZnTbSsFW6VZjFMjQIDAQABo4Ha
+    MIHXMB0GA1UdDgQWBBTx0lDzjH/iOBnOSQaSEWQLx1syGDCBpwYDVR0jBIGfMIGc
+    gBTx0lDzjH/iOBnOSQaSEWQLx1syGKGBgKR+MHwxCzAJBgNVBAYTAmF3MQ4wDAYD
+    VQQIEwVhcnViYTEOMAwGA1UEChMFYXJ1YmExDjAMBgNVBAcTBWFydWJhMQ4wDAYD
+    VQQLEwVhcnViYTEOMAwGA1UEAxMFYXJ1YmExHTAbBgkqhkiG9w0BCQEWDmFydWJh
+    QGFydWJhLmFyggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADgYEAYvBJ
+    0HOZbbHClXmGUjGs+GS+xC1FO/am2suCSYqNB9dyMXfOWiJ1+TLJk+o/YZt8vuxC
+    KdcZYgl4l/L6PxJ982SRhc83ZW2dkAZI4M0/Ud3oePe84k8jm3A7EvH5wi5hvCkK
+    RpuRBwn3Ei+jCRouxTbzKPsuCVB+1sNyxMTXzf0=
+    -----END CERTIFICATE-----
+  saml:
+    signMetaData: true
+    signRequest: true
+    wantAssertionSigned: true
+    disableInResponseToCheck: false
+    signatureAlgorithm: SHA256
+    socket:
+      connectionManagerTimeout: 10000
+      soTimeout: 10000
+    providers:
+      okta-signed-or-encrypted:
+        idpMetadata: |
+          <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="http://www.okta.com/k36wkjw6EAEJVZXFFDAU"><md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIICmTCCAgKgAwIBAgIGAUPATqmEMA0GCSqGSIb3DQEBBQUAMIGPMQswCQYDVQQGEwJVUzETMBEG
+          A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+          MBIGA1UECwwLU1NPUHJvdmlkZXIxEDAOBgNVBAMMB1Bpdm90YWwxHDAaBgkqhkiG9w0BCQEWDWlu
+          Zm9Ab2t0YS5jb20wHhcNMTQwMTIzMTgxMjM3WhcNNDQwMTIzMTgxMzM3WjCBjzELMAkGA1UEBhMC
+          VVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xDTALBgNVBAoM
+          BE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMRAwDgYDVQQDDAdQaXZvdGFsMRwwGgYJKoZIhvcN
+          AQkBFg1pbmZvQG9rdGEuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCeil67/TLOiTZU
+          WWgW2XEGgFZ94bVO90v5J1XmcHMwL8v5Z/8qjdZLpGdwI7Ph0CyXMMNklpaR/Ljb8fsls3amdT5O
+          Bw92Zo8ulcpjw2wuezTwL0eC0wY/GQDAZiXL59npE6U+fH1lbJIq92hx0HJSru/0O1q3+A/+jjZL
+          3tL/SwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAI5BoWZoH6Mz9vhypZPOJCEKa/K+biZQsA4Zqsuk
+          vvphhSERhqk/Nv76Vkl8uvJwwHbQrR9KJx4L3PRkGCG24rix71jEuXVGZUsDNM3CUKnARx4MEab6
+          GFHNkZ6DmoT/PFagngecHu+EwmuDtaG0rEkFrARwe+d8Ru0BN558abFb</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://pivotal.oktapreview.com/app/pivotal_cfsamltemplate1_1/k36wkjw6EAEJVZXFFDAU/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://pivotal.oktapreview.com/app/pivotal_cfsamltemplate1_1/k36wkjw6EAEJVZXFFDAU/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+        nameID: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+        assertionConsumerIndex: 0
+        metadataTrustCheck: true
+        showSamlLoginLink: true
+        linkText: 'Okta Preview Signed'
+      okta-local:
+        idpMetadata: https://pivotal.oktapreview.com/app/k36wkjw6EAEJVZXFFDAU/sso/saml/metadata
+        nameID: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+        assertionConsumerIndex: 0
+        metadataTrustCheck: true
+        showSamlLoginLink: true
+        linkText: 'Okta Preview 1'
+        iconUrl: 'http://link.to/icon.jpg'
+        addShadowUserOnLogin: true
+        externalGroupsWhitelist:
+          - admin
+          - user
+        emailDomain:
+          - example.com
+        attributeMappings:
+          given_name: firstName
+          family_name: surname
+        providerDescription: 'Human readable description of this provider'
+  oauth:
+    externalGroupsFromMappedAuthorities: false
+  authorize:
+    url: https://uaa.bosh-lite.com/oauth/authorize
+
+servlet:
+  session-store: memory
+  idle-timeout: 1800
+  session-cookie:
+    max-age: -1
+    encode-base64: true
+
+rest:
+  template:
+    timeout: 10000
+    maxTotal: 20
+    maxPerRoute: 5
+    maxKeepAlive: 0
+    validateAfterInactivity: 2000
+    retryCount: 0
+cors:
+  enforceSystemZonePolicyInAllZones: true
+csp:
+  script-src:
+    - "'self'"
+global:
+  jwk:
+    oidc-trust:
+      key: "key-value"
+      cert: "cert-value"
+    uaa:
+      key: "uaa-zone-key-value"
+      cert: "uaa-zone-cert-value"

--- a/spec/compare/default-log4j2-template-defaults.properties
+++ b/spec/compare/default-log4j2-template-defaults.properties
@@ -1,0 +1,85 @@
+status = error
+dest = err
+name = UaaLog
+
+property.log_directory = /var/vcap/sys/log/uaa
+property.log_pattern=[EXPECTED_LOG_PATTERN_PLACEHOLDER] uaa%X{context} - %pid [%t] - [%X{traceId},%X{spanId}] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=|code=|access_token=|refresh_token=|id_token=)([^&\s]*)}{<redacted>}%n
+
+appender.uaaDefaultAppender.type = File
+appender.uaaDefaultAppender.name = UaaDefaultAppender
+appender.uaaDefaultAppender.fileName = ${log_directory}/uaa.log
+appender.uaaDefaultAppender.layout.type = PatternLayout
+appender.uaaDefaultAppender.layout.pattern = ${log_pattern}
+
+appender.uaaAuditAppender.type = File
+appender.uaaAuditAppender.name = UaaAuditAppender
+appender.uaaAuditAppender.fileName = ${log_directory}/uaa_events.log
+appender.uaaAuditAppender.layout.type = PatternLayout
+appender.uaaAuditAppender.layout.pattern = ${log_pattern}
+
+rootLogger.level = info
+rootLogger.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.UAAAudit.name = UAA.Audit
+logger.UAAAudit.level = info
+logger.UAAAudit.additivity = true
+logger.UAAAudit.appenderRef.auditEventLog.ref = UaaAuditAppender
+
+
+# These loggers have a configurable level
+logger.cfIdentity.name = org.cloudfoundry.identity
+logger.cfIdentity.level = INFO
+logger.cfIdentity.additivity = false
+logger.cfIdentity.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springSecurity.name = org.springframework.security
+logger.springSecurity.level = INFO
+logger.springSecurity.additivity = false
+logger.springSecurity.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springJdbc.name = org.springframework.jdbc
+logger.springJdbc.level = INFO
+logger.springJdbc.additivity = false
+logger.springJdbc.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+
+# These loggers have a fixed level of "info"
+logger.springWebStandardServletEnvironment.name = org.springframework.web.context.support.StandardServletEnvironment
+logger.springWebStandardServletEnvironment.level = info
+logger.springWebStandardServletEnvironment.additivity = false
+logger.springWebStandardServletEnvironment.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.apacheHttpWire.name = org.apache.http.wire
+logger.apacheHttpWire.level = info
+logger.apacheHttpWire.additivity = false
+logger.apacheHttpWire.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springAopAspectJExpressionPointcut.name = org.springframework.aop.aspectj.AspectJExpressionPointcut
+logger.springAopAspectJExpressionPointcut.level = info
+logger.springAopAspectJExpressionPointcut.additivity = false
+logger.springAopAspectJExpressionPointcut.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springBeansDefaultListableBeanFactory.name = org.springframework.beans.factory.support.DefaultListableBeanFactory
+logger.springBeansDefaultListableBeanFactory.level = info
+logger.springBeansDefaultListableBeanFactory.additivity = false
+logger.springBeansDefaultListableBeanFactory.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springBeansDisposableBeanAdaptor.name = org.springframework.beans.factory.support.DisposableBeanAdapter
+logger.springBeansDisposableBeanAdaptor.level = info
+logger.springBeansDisposableBeanAdaptor.additivity = false
+logger.springBeansDisposableBeanAdaptor.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springSecurityLdapAuthenticationProvider.name = org.springframework.security.ldap.authentication.LdapAuthenticationProvider
+logger.springSecurityLdapAuthenticationProvider.level = info
+logger.springSecurityLdapAuthenticationProvider.additivity = false
+logger.springSecurityLdapAuthenticationProvider.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springSecurityFilterBasedUserSearch.name = org.springframework.security.ldap.search.FilterBasedLdapUserSearch
+logger.springSecurityFilterBasedUserSearch.level = info
+logger.springSecurityFilterBasedUserSearch.additivity = false
+logger.springSecurityFilterBasedUserSearch.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springWeb.name = org.springframework.web
+logger.springWeb.level = info
+logger.springWeb.additivity = false
+logger.springWeb.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender

--- a/spec/compare/default-log4j2-template.properties
+++ b/spec/compare/default-log4j2-template.properties
@@ -3,7 +3,7 @@ dest = err
 name = UaaLog
 
 property.log_directory = /var/vcap/sys/log/uaa
-property.log_pattern=[EXPECTED_LOG_PATTERN_PLACEHOLDER] uaa%X{context} - %pid [%t] - [%X{traceId},%X{spanId}] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=)([^&]*)}{<redacted>}%n
+property.log_pattern=[EXPECTED_LOG_PATTERN_PLACEHOLDER] uaa%X{context} - %pid [%t] - [%X{traceId},%X{spanId}] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=|code=|access_token=|refresh_token=|id_token=)([^&\s]*)}{<redacted>}%n
 
 appender.uaaDefaultAppender.type = File
 appender.uaaDefaultAppender.name = UaaDefaultAppender

--- a/spec/compare/default-log4j2.properties
+++ b/spec/compare/default-log4j2.properties
@@ -3,7 +3,7 @@ dest = err
 name = UaaLog
 
 property.log_directory = /var/vcap/sys/log/uaa
-property.log_pattern=[%d{yyyy-MM-dd'T'HH:mm:ss.nnnnnn}{GMT+0}Z] uaa%X{context} - %pid [%t] - [%X{traceId},%X{spanId}] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=)([^&]*)}{<redacted>}%n
+property.log_pattern=[%d{yyyy-MM-dd'T'HH:mm:ss.nnnnnn}{GMT+0}Z] uaa%X{context} - %pid [%t] - [%X{traceId},%X{spanId}] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=|code=|access_token=|refresh_token=|id_token=)([^&\s]*)}{<redacted>}%n
 
 appender.uaaDefaultAppender.type = File
 appender.uaaDefaultAppender.name = UaaDefaultAppender

--- a/spec/compare/deprecated-properties-still-work-uaa-defaults.yml
+++ b/spec/compare/deprecated-properties-still-work-uaa-defaults.yml
@@ -1,0 +1,278 @@
+---
+name: uaa
+encryption:
+  active_key_label: key1
+  encryption_keys:
+    - label: key1
+      passphrase: my-passphrase
+disableInternalAuth: false
+disableInternalUserManagement: false
+issuer:
+  uri: http://test.uaa.url
+spring_profiles: mysql
+logging:
+  config: "/var/vcap/jobs/uaa/config/log4j2.properties"
+database:
+  url: jdbc:mysql://10.244.0.30:1433/uaadb?useSSL=true
+  username: uaaadmin
+  password: admin
+  maxactive: 100
+  maxidle: 10
+  minidle: 0
+  removeabandoned: false
+  logabandoned: true
+  abandonedtimeout: 300
+  testwhileidle: false
+authentication:
+  enableUriEncodingCompatibilityMode: false
+  policy:
+    lockoutAfterFailures: 5
+    countFailuresWithinSeconds: 1200
+    lockoutPeriodSeconds: 300
+    global:
+      lockoutAfterFailures: 5
+      countFailuresWithinSeconds: 3600
+      lockoutPeriodSeconds: 300
+password:
+  policy:
+    minLength: 0
+    maxLength: 255
+    requireUpperCaseCharacter: 0
+    requireLowerCaseCharacter: 0
+    requireDigit: 0
+    requireSpecialCharacter: 0
+    expirePasswordInMonths: 0
+    global:
+      minLength: 0
+      maxLength: 255
+      requireUpperCaseCharacter: 0
+      requireLowerCaseCharacter: 0
+      requireDigit: 0
+      requireSpecialCharacter: 0
+      expirePasswordInMonths: 0
+zones:
+  internal:
+    hostnames: []
+jwt:
+  token:
+    queryString:
+      enabled: true
+    revocable: false
+    policy:
+      accessTokenValiditySeconds: 43200
+      refreshTokenValiditySeconds: 2592000
+      global:
+        accessTokenValiditySeconds: 43200
+        refreshTokenValiditySeconds: 2592000
+      activeKeyId: key-1
+      keys:
+        key-1:
+          signingKey: |
+            -----BEGIN RSA PRIVATE KEY-----
+            MIICXgIBAAKBgQDfTLadf6QgJeS2XXImEHMsa+1O7MmIt44xaL77N2K+J/JGpfV3
+            AnkyB06wFZ02sBLB7hko42LIsVEOyTuUBird/3vlyHFKytG7UEt60Fl88SbAEfsU
+            JN1i1aSUlunPS/NCz+BKwwKFP9Ss3rNImE9Uc2LMvGy153LHFVW2zrjhTwIDAQAB
+            AoGBAJDh21LRcJITRBQ3CUs9PR1DYZPl+tUkE7RnPBMPWpf6ny3LnDp9dllJeHqz
+            a3ACSgleDSEEeCGzOt6XHnrqjYCKa42Z+Opnjx/OOpjyX1NAaswRtnb039jwv4gb
+            RlwT49Y17UAQpISOo7JFadCBoMG0ix8xr4ScY+zCSoG5v0BhAkEA8llNsiWBJF5r
+            LWQ6uimfdU2y1IPlkcGAvjekYDkdkHiRie725Dn4qRiXyABeaqNm2bpnD620Okwr
+            sf7LY+BMdwJBAOvgt/ZGwJrMOe/cHhbujtjBK/1CumJ4n2r5V1zPBFfLNXiKnpJ6
+            J/sRwmjgg4u3Anu1ENF3YsxYabflBnvOP+kCQCQ8VBCp6OhOMcpErT8+j/gTGQUL
+            f5zOiPhoC2zTvWbnkCNGlqXDQTnPUop1+6gILI2rgFNozoTU9MeVaEXTuLsCQQDC
+            AGuNpReYucwVGYet+LuITyjs/krp3qfPhhByhtndk4cBA5H0i4ACodKyC6Zl7Tmf
+            oYaZoYWi6DzbQQUaIsKxAkEA2rXQjQFsfnSm+w/9067ChWg46p4lq5Na2NpcpFgH
+            waZKhM1W0oB8MX78M+0fG3xGUtywTx0D4N7pr1Tk2GTgNw==
+            -----END RSA PRIVATE KEY-----
+    refresh:
+      restrict_grant: false
+      unique: false
+      rotate: false
+      format: jwt
+oauth:
+  clients:
+    admin:
+      authorized-grant-types: client_credentials
+      authorities: clients.read,clients.write,clients.secret,uaa.admin,scim.read,scim.write,password.write
+      id: admin
+      secret:
+  user:
+    authorities:
+    - openid
+    - scim.me
+    - cloud_controller.read
+    - cloud_controller.write
+    - cloud_controller_service_permissions.read
+    - password.write
+    - uaa.user
+    - approvals.me
+    - oauth.approvals
+    - notification_preferences.read
+    - notification_preferences.write
+    - profile
+    - roles
+    - user_attributes
+    - uaa.offline_token
+  authorize:
+    ssl: true
+scim:
+  userids_enabled: true
+  user:
+    override: true
+assetBaseUrl: "/resources/oss"
+logout:
+  redirect:
+    url: "/login"
+    parameter:
+      disable: false
+
+require_https: true
+https_port: 8443
+
+uaa:
+  url: http://test.uaa.url
+  limitedFunctionality:
+    statusFile: /var/vcap/data/uaa/bbr_limited_mode.lock
+    whitelist:
+      endpoints:
+      - /oauth/authorize/**
+      - /oauth/token/**
+      - /check_token/**
+      methods:
+      - GET
+      - HEAD
+  shutdown:
+    sleep: 5000
+  oauth:
+    redirect_uri:
+      allow_unsafe_matching: false
+
+links:
+  passwd: "/forgot_password"
+  signup: "/create_account"
+  homeRedirect: "http://deprecated.home.redirect"
+  global:
+    passwd: "/forgot_password"
+    signup: "/create_account"
+    homeRedirect: "/"
+
+login:
+  selfServiceLinksEnabled: true
+  serviceProviderKey: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEogIBAAKCAQEAugUFbC5/uBVijrEdFu5xTP77D8iK8kM7QN1E2kteISwTMqOq
+    1IOTvx3P1i0ZZDypEwhxHD6M/flVjXJNiRIPYd+8wkjTUKHo0fdVXZxkeAczANX5
+    YYcnSUy3ztMQNPnA7cjhe5nL+jL9t13L/nONBOC1FHVdeqiKjpEPm3iXbIp1ppRt
+    a5UuA0JTETKuQ9gXqT0wKE8QHGReI1NTpBFPkyUSG+ojeqtqVM2oOjFtp8lY6nFe
+    BUQjfnWkhuLeznH1FLovi0K9V6a4zDk3g6B0A+0J4Q/CTW3NJW20ElWGmNseWlC4
+    FKa20CCf39x3RcWQ4mC3blkm5GvisI+a4k+91QIDAQABAoIBAGDaAGrFAwaLS9dT
+    a/vmheM61uju1zkvvAgXrKOjngzTb+Nrx6QCJcjZ8r5mmNPRqY4ZVRsJjkslqF+O
+    5cO6PXwOC690T2GqCxhXGIE2zjCYPvvubHtU7SWC5iivR77tUn/7mTrLZqKMLgFs
+    uqtu6jth66YNPXCBlDKKYH/oF58QzF8XOL0ZDTrKse2ps0X2TPXLAx58h1FEHKay
+    IncS8MXAan/U1CsobWJFReXKh1uZXNevBeKec1uJmVgKhyPpDYYwXMeHwQhZ4+qZ
+    4LAf2FQHe7DKzvMIL+3doWjg8Iuh5wZztvv+ilv4OnM+XcvxyjmJXbniBEuwBwhG
+    ncVARcECgYEA6Le2mNtUbcc7A3jy6oeFUxWN0PKXChGK1gdx5B30FsWgwMJT8B/5
+    US7pKCJXoVxiOUmvf3kNkNjdJQTsRcjZnULU1Ma7zZ+QQ3HAvv4h72i5dNAq8R77
+    m4rUFIvmw+uY5jj5GxzweiFiJRFfEeXbVbZ42ut5eC0QqmohCepFuO0CgYEAzKFL
+    N8n+YaTtz+J3bRHDzvmCUfL+jGndlWmKXjbNYavSXy7EfbBmUaqjAJpUtdDtP/Da
+    2xloVFx794zbnCO9GDCA0FzPBCAFM19wVBMIPs3UaGTjUYzdKDXcJUps1EIifmky
+    D1Z4zdJr53Yt6/tmUjG3OIMtAHcxTjXLREeJA4kCgYAaZcx2plp7YWAWUr/rTpgX
+    BpjhnML5R2giQxHuOF+Zva0wcFqpIFddmB6miM675QjXSr53jTm2toLPUjGi8NeO
+    eSg/QpPHDVSF8f9VKuqah5yR3ZMhasxLpoHMGtqAWtcrNkc7hhrZH7RMVB4en54z
+    qNEotBFBSotbaVJ6F3L1OQKBgGurFnu1Qa647BQs0a/G4CNgL0zVMVBKR7fc/1wR
+    M8GHebpxThvgHAYuZXPkwFumIZ86KL2NwdJZkzSuncKrH0zCAJUhsB84heQA/IaQ
+    OQ9ql6+SHfWDy73jkQDiBx8r6SBgU2G0mv2ZEQOJsCHxdmYbGI+Yna4YCQ5gyaIU
+    jagZAoGAK8uj/kErsP42jrjT0jiwFCRAYdsxqaZYotH/GIjF0pwOgzZw0nxD196Z
+    r8ZGJ8TtbkUybJdIA5a6DPawayIiDfFMFGzYB1Rbds39So3daDLwG625Iy/XLwKL
+    PGmj6PrsJmxY4IJfqLbGFgD9jUu+ZKZ5FmfmvQB+m2eODSsr9Po=
+    -----END RSA PRIVATE KEY-----
+  serviceProviderKeyPassword: ""
+  serviceProviderCertificate: |
+    -----BEGIN CERTIFICATE-----
+    MIIEVzCCAz+gAwIBAgIJALO14WHj4newMA0GCSqGSIb3DQEBCwUAMIHAMQswCQYD
+    VQQGEwJVUzELMAkGA1UECAwCQ0ExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xITAf
+    BgNVBAoMGFVBQSBSZWxlYXNlIFNwZWMgVGVzdGluZzEUMBIGA1UECwwLVUFBIFJF
+    TEVBU0UxLDAqBgNVBAMMI2dpdGh1Yi5jb20vY2xvdWRmb3VuZHJ5L3VhYS1yZWxl
+    YXNlMSUwIwYJKoZIhvcNAQkBFhZ1YWEtcmVsZWFzZUBnaXRodWIuY29tMCAXDTE3
+    MDEwMzE2MjcxMVoYDzIxMTYxMjEwMTYyNzExWjCBwDELMAkGA1UEBhMCVVMxCzAJ
+    BgNVBAgMAkNBMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMSEwHwYDVQQKDBhVQUEg
+    UmVsZWFzZSBTcGVjIFRlc3RpbmcxFDASBgNVBAsMC1VBQSBSRUxFQVNFMSwwKgYD
+    VQQDDCNnaXRodWIuY29tL2Nsb3VkZm91bmRyeS91YWEtcmVsZWFzZTElMCMGCSqG
+    SIb3DQEJARYWdWFhLXJlbGVhc2VAZ2l0aHViLmNvbTCCASIwDQYJKoZIhvcNAQEB
+    BQADggEPADCCAQoCggEBALoFBWwuf7gVYo6xHRbucUz++w/IivJDO0DdRNpLXiEs
+    EzKjqtSDk78dz9YtGWQ8qRMIcRw+jP35VY1yTYkSD2HfvMJI01Ch6NH3VV2cZHgH
+    MwDV+WGHJ0lMt87TEDT5wO3I4XuZy/oy/bddy/5zjQTgtRR1XXqoio6RD5t4l2yK
+    daaUbWuVLgNCUxEyrkPYF6k9MChPEBxkXiNTU6QRT5MlEhvqI3qralTNqDoxbafJ
+    WOpxXgVEI351pIbi3s5x9RS6L4tCvVemuMw5N4OgdAPtCeEPwk1tzSVttBJVhpjb
+    HlpQuBSmttAgn9/cd0XFkOJgt25ZJuRr4rCPmuJPvdUCAwEAAaNQME4wHQYDVR0O
+    BBYEFLfbFn7Gz0J0HB/wztQpJngzt7eOMB8GA1UdIwQYMBaAFLfbFn7Gz0J0HB/w
+    ztQpJngzt7eOMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAJea03gj
+    hlljisw0e31Buo/R4b7sH6Hho2klGCFLqqk+yJe5T2R8zmOJ6ygbKT6vnUb6KuDB
+    gIThFoAkMR9OQBPvK/2BB6oLocoQ7vNTnPYqmGKLhI6jPHu6jYxG0LFdFhuKMSAW
+    rsI2hVjobEfjSj8HnEDoXqEwDBpz4hgfNPt/BDrxau3nsDGRyJ3FFBjrQMOb3oKA
+    JXdktdSrILgG0XhvdA5R6cnTmT+xYRUzzkOFmF2lJjQIUIxBhW3xY6O4jgwNBFB3
+    4ioCYqGCr9OdIC6IpnFoxnGyCjwtPzP931wVUbMUZObFGcy7SmqHv8gQP3w5YG2i
+    g8U152rRBEMHBaM=
+    -----END CERTIFICATE-----
+
+  url: http://test.uaa.url
+  defaultIdentityProvider: uaa
+  idpDiscoveryEnabled: false
+  accountChooserEnabled: false
+  aliasEntitiesEnabled: false
+  checkOriginEnabled: false
+  allowOriginLoop: true
+  entityBaseURL: http://test.uaa.url
+  entityID: test.uaa.url
+  prompt:
+    username:
+      text: Email
+    password:
+      text: Password
+  authorize:
+    url: http://test.uaa.url/oauth/authorize
+  oauth:
+    externalGroupsFromMappedAuthorities: false
+  saml:
+    socket:
+      connectionManagerTimeout: 10000
+      soTimeout: 10000
+    signMetaData: true
+    signRequest: true
+    wantAssertionSigned: true
+    disableInResponseToCheck: false
+smtp:
+  host: localhost
+  port: 2525
+  auth: false
+  starttls: false
+  sslprotocols: TLSv1.2
+
+servlet:
+  session-store: memory
+  idle-timeout: 1800
+  session-cookie:
+    max-age: -1
+    encode-base64: true
+
+rest:
+  template:
+    timeout: 10000
+    maxTotal: 20
+    maxPerRoute: 5
+    maxKeepAlive: 0
+    validateAfterInactivity: 2000
+    retryCount: 0
+
+cors:
+  enforceSystemZonePolicyInAllZones: true
+csp:
+  script-src:
+    - "'self'"
+global:
+  jwk:
+    oidc-trust:
+      key: "key-value"
+      cert: "cert-value"
+    uaa:
+      key: "uaa-zone-key-value"
+      cert: "uaa-zone-cert-value"

--- a/spec/compare/test-defaults-log4j2-defaults.properties
+++ b/spec/compare/test-defaults-log4j2-defaults.properties
@@ -1,0 +1,85 @@
+status = error
+dest = err
+name = UaaLog
+
+property.log_directory = /var/vcap/sys/log/uaa
+property.log_pattern=[%d{yyyy-MM-dd'T'HH:mm:ss.nnnnnn}{GMT+0}Z] uaa%X{context} - %pid [%t] - [%X{traceId},%X{spanId}] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=|code=|access_token=|refresh_token=|id_token=)([^&\s]*)}{<redacted>}%n
+
+appender.uaaDefaultAppender.type = File
+appender.uaaDefaultAppender.name = UaaDefaultAppender
+appender.uaaDefaultAppender.fileName = ${log_directory}/uaa.log
+appender.uaaDefaultAppender.layout.type = PatternLayout
+appender.uaaDefaultAppender.layout.pattern = ${log_pattern}
+
+appender.uaaAuditAppender.type = File
+appender.uaaAuditAppender.name = UaaAuditAppender
+appender.uaaAuditAppender.fileName = ${log_directory}/uaa_events.log
+appender.uaaAuditAppender.layout.type = PatternLayout
+appender.uaaAuditAppender.layout.pattern = ${log_pattern}
+
+rootLogger.level = info
+rootLogger.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.UAAAudit.name = UAA.Audit
+logger.UAAAudit.level = info
+logger.UAAAudit.additivity = true
+logger.UAAAudit.appenderRef.auditEventLog.ref = UaaAuditAppender
+
+
+# These loggers have a configurable level
+logger.cfIdentity.name = org.cloudfoundry.identity
+logger.cfIdentity.level = INFO
+logger.cfIdentity.additivity = false
+logger.cfIdentity.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springSecurity.name = org.springframework.security
+logger.springSecurity.level = INFO
+logger.springSecurity.additivity = false
+logger.springSecurity.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springJdbc.name = org.springframework.jdbc
+logger.springJdbc.level = INFO
+logger.springJdbc.additivity = false
+logger.springJdbc.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+
+# These loggers have a fixed level of "info"
+logger.springWebStandardServletEnvironment.name = org.springframework.web.context.support.StandardServletEnvironment
+logger.springWebStandardServletEnvironment.level = info
+logger.springWebStandardServletEnvironment.additivity = false
+logger.springWebStandardServletEnvironment.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.apacheHttpWire.name = org.apache.http.wire
+logger.apacheHttpWire.level = info
+logger.apacheHttpWire.additivity = false
+logger.apacheHttpWire.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springAopAspectJExpressionPointcut.name = org.springframework.aop.aspectj.AspectJExpressionPointcut
+logger.springAopAspectJExpressionPointcut.level = info
+logger.springAopAspectJExpressionPointcut.additivity = false
+logger.springAopAspectJExpressionPointcut.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springBeansDefaultListableBeanFactory.name = org.springframework.beans.factory.support.DefaultListableBeanFactory
+logger.springBeansDefaultListableBeanFactory.level = info
+logger.springBeansDefaultListableBeanFactory.additivity = false
+logger.springBeansDefaultListableBeanFactory.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springBeansDisposableBeanAdaptor.name = org.springframework.beans.factory.support.DisposableBeanAdapter
+logger.springBeansDisposableBeanAdaptor.level = info
+logger.springBeansDisposableBeanAdaptor.additivity = false
+logger.springBeansDisposableBeanAdaptor.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springSecurityLdapAuthenticationProvider.name = org.springframework.security.ldap.authentication.LdapAuthenticationProvider
+logger.springSecurityLdapAuthenticationProvider.level = info
+logger.springSecurityLdapAuthenticationProvider.additivity = false
+logger.springSecurityLdapAuthenticationProvider.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springSecurityFilterBasedUserSearch.name = org.springframework.security.ldap.search.FilterBasedLdapUserSearch
+logger.springSecurityFilterBasedUserSearch.level = info
+logger.springSecurityFilterBasedUserSearch.additivity = false
+logger.springSecurityFilterBasedUserSearch.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender
+
+logger.springWeb.name = org.springframework.web
+logger.springWeb.level = info
+logger.springWeb.additivity = false
+logger.springWeb.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender

--- a/spec/compare/test-defaults-uaa-defaults.yml
+++ b/spec/compare/test-defaults-uaa-defaults.yml
@@ -1,0 +1,288 @@
+---
+name: uaa
+encryption:
+  active_key_label: key1
+  encryption_keys:
+    - label: key1
+      passphrase: my-passphrase
+disableInternalAuth: false
+disableInternalUserManagement: false
+issuer:
+  uri: http://test.uaa.url
+spring_profiles: postgresql
+logging:
+  config: "/var/vcap/jobs/uaa/config/log4j2.properties"
+database:
+  url: jdbc:postgresql://10.244.0.30:1433/uaadb?sslmode=verify-full&sslfactory=org.postgresql.ssl.DefaultJavaSSLFactory
+  username: uaaadmin
+  password: admin
+  maxactive: 100
+  maxidle: 10
+  minidle: 0
+  removeabandoned: false
+  logabandoned: true
+  abandonedtimeout: 300
+  testwhileidle: false
+authentication:
+  enableUriEncodingCompatibilityMode: false
+  policy:
+    lockoutAfterFailures: 5
+    countFailuresWithinSeconds: 1200
+    lockoutPeriodSeconds: 300
+    global:
+      lockoutAfterFailures: 5
+      countFailuresWithinSeconds: 3600
+      lockoutPeriodSeconds: 300
+password:
+  policy:
+    minLength: 0
+    maxLength: 255
+    requireUpperCaseCharacter: 0
+    requireLowerCaseCharacter: 0
+    requireDigit: 0
+    requireSpecialCharacter: 0
+    expirePasswordInMonths: 0
+    global:
+      minLength: 0
+      maxLength: 255
+      requireUpperCaseCharacter: 0
+      requireLowerCaseCharacter: 0
+      requireDigit: 0
+      requireSpecialCharacter: 0
+      expirePasswordInMonths: 0
+zones:
+  internal:
+    hostnames: []
+jwt:
+  token:
+    queryString:
+      enabled: true
+    revocable: false
+    policy:
+      accessTokenValiditySeconds: 43200
+      refreshTokenValiditySeconds: 2592000
+      global:
+        accessTokenValiditySeconds: 43200
+        refreshTokenValiditySeconds: 2592000
+      activeKeyId: key-1
+      keys:
+        key-1:
+          signingKey: |
+            -----BEGIN RSA PRIVATE KEY-----
+            MIICXgIBAAKBgQDfTLadf6QgJeS2XXImEHMsa+1O7MmIt44xaL77N2K+J/JGpfV3
+            AnkyB06wFZ02sBLB7hko42LIsVEOyTuUBird/3vlyHFKytG7UEt60Fl88SbAEfsU
+            JN1i1aSUlunPS/NCz+BKwwKFP9Ss3rNImE9Uc2LMvGy153LHFVW2zrjhTwIDAQAB
+            AoGBAJDh21LRcJITRBQ3CUs9PR1DYZPl+tUkE7RnPBMPWpf6ny3LnDp9dllJeHqz
+            a3ACSgleDSEEeCGzOt6XHnrqjYCKa42Z+Opnjx/OOpjyX1NAaswRtnb039jwv4gb
+            RlwT49Y17UAQpISOo7JFadCBoMG0ix8xr4ScY+zCSoG5v0BhAkEA8llNsiWBJF5r
+            LWQ6uimfdU2y1IPlkcGAvjekYDkdkHiRie725Dn4qRiXyABeaqNm2bpnD620Okwr
+            sf7LY+BMdwJBAOvgt/ZGwJrMOe/cHhbujtjBK/1CumJ4n2r5V1zPBFfLNXiKnpJ6
+            J/sRwmjgg4u3Anu1ENF3YsxYabflBnvOP+kCQCQ8VBCp6OhOMcpErT8+j/gTGQUL
+            f5zOiPhoC2zTvWbnkCNGlqXDQTnPUop1+6gILI2rgFNozoTU9MeVaEXTuLsCQQDC
+            AGuNpReYucwVGYet+LuITyjs/krp3qfPhhByhtndk4cBA5H0i4ACodKyC6Zl7Tmf
+            oYaZoYWi6DzbQQUaIsKxAkEA2rXQjQFsfnSm+w/9067ChWg46p4lq5Na2NpcpFgH
+            waZKhM1W0oB8MX78M+0fG3xGUtywTx0D4N7pr1Tk2GTgNw==
+            -----END RSA PRIVATE KEY-----
+    refresh:
+      restrict_grant: false
+      unique: false
+      rotate: false
+      format: jwt
+oauth:
+  clients:
+    admin:
+      authorized-grant-types: client_credentials
+      authorities: clients.read,clients.write,clients.secret,uaa.admin,scim.read,scim.write,password.write
+      id: admin
+      secret:
+  user:
+    authorities:
+    - openid
+    - scim.me
+    - cloud_controller.read
+    - cloud_controller.write
+    - cloud_controller_service_permissions.read
+    - password.write
+    - uaa.user
+    - approvals.me
+    - oauth.approvals
+    - notification_preferences.read
+    - notification_preferences.write
+    - profile
+    - roles
+    - user_attributes
+    - uaa.offline_token
+  authorize:
+    ssl: true
+scim:
+  userids_enabled: true
+  user:
+    override: true
+assetBaseUrl: "/resources/oss"
+logout:
+  redirect:
+    url: "/login"
+    parameter:
+      disable: false
+
+require_https: true
+https_port: 8443
+
+uaa:
+  url: http://test.uaa.url
+  limitedFunctionality:
+    statusFile: /var/vcap/data/uaa/bbr_limited_mode.lock
+    whitelist:
+      endpoints:
+      - /oauth/authorize/**
+      - /oauth/token/**
+      - /check_token/**
+      - /login/**
+      - /login.do
+      - /logout/**
+      - /logout.do
+      - /saml/**
+      - /autologin/**
+      - /authenticate/**
+      - /idp_discovery/**
+      methods:
+      - GET
+      - HEAD
+      - OPTIONS
+  shutdown:
+    sleep: 5000
+  oauth:
+    redirect_uri:
+      allow_unsafe_matching: false
+
+links:
+  global:
+    passwd: "/forgot_password"
+    signup: "/create_account"
+    homeRedirect: "/"
+  passwd: "/forgot_password"
+  signup: "/create_account"
+  homeRedirect: "/"
+login:
+  selfServiceLinksEnabled: true
+  url: http://test.uaa.url
+  defaultIdentityProvider: uaa
+  idpDiscoveryEnabled: false
+  accountChooserEnabled: false
+  aliasEntitiesEnabled: false
+  checkOriginEnabled: false
+  allowOriginLoop: true
+  entityBaseURL: http://test.uaa.url
+  entityID: test.uaa.url
+  prompt:
+    username:
+      text: Email
+    password:
+      text: Password
+  authorize:
+    url: http://test.uaa.url/oauth/authorize
+  oauth:
+    externalGroupsFromMappedAuthorities: false
+  saml:
+    activeKeyId: saml-key-1
+    keys:
+      saml-key-1:
+        key: |
+          -----BEGIN RSA PRIVATE KEY-----
+          MIIEogIBAAKCAQEAugUFbC5/uBVijrEdFu5xTP77D8iK8kM7QN1E2kteISwTMqOq
+          1IOTvx3P1i0ZZDypEwhxHD6M/flVjXJNiRIPYd+8wkjTUKHo0fdVXZxkeAczANX5
+          YYcnSUy3ztMQNPnA7cjhe5nL+jL9t13L/nONBOC1FHVdeqiKjpEPm3iXbIp1ppRt
+          a5UuA0JTETKuQ9gXqT0wKE8QHGReI1NTpBFPkyUSG+ojeqtqVM2oOjFtp8lY6nFe
+          BUQjfnWkhuLeznH1FLovi0K9V6a4zDk3g6B0A+0J4Q/CTW3NJW20ElWGmNseWlC4
+          FKa20CCf39x3RcWQ4mC3blkm5GvisI+a4k+91QIDAQABAoIBAGDaAGrFAwaLS9dT
+          a/vmheM61uju1zkvvAgXrKOjngzTb+Nrx6QCJcjZ8r5mmNPRqY4ZVRsJjkslqF+O
+          5cO6PXwOC690T2GqCxhXGIE2zjCYPvvubHtU7SWC5iivR77tUn/7mTrLZqKMLgFs
+          uqtu6jth66YNPXCBlDKKYH/oF58QzF8XOL0ZDTrKse2ps0X2TPXLAx58h1FEHKay
+          IncS8MXAan/U1CsobWJFReXKh1uZXNevBeKec1uJmVgKhyPpDYYwXMeHwQhZ4+qZ
+          4LAf2FQHe7DKzvMIL+3doWjg8Iuh5wZztvv+ilv4OnM+XcvxyjmJXbniBEuwBwhG
+          ncVARcECgYEA6Le2mNtUbcc7A3jy6oeFUxWN0PKXChGK1gdx5B30FsWgwMJT8B/5
+          US7pKCJXoVxiOUmvf3kNkNjdJQTsRcjZnULU1Ma7zZ+QQ3HAvv4h72i5dNAq8R77
+          m4rUFIvmw+uY5jj5GxzweiFiJRFfEeXbVbZ42ut5eC0QqmohCepFuO0CgYEAzKFL
+          N8n+YaTtz+J3bRHDzvmCUfL+jGndlWmKXjbNYavSXy7EfbBmUaqjAJpUtdDtP/Da
+          2xloVFx794zbnCO9GDCA0FzPBCAFM19wVBMIPs3UaGTjUYzdKDXcJUps1EIifmky
+          D1Z4zdJr53Yt6/tmUjG3OIMtAHcxTjXLREeJA4kCgYAaZcx2plp7YWAWUr/rTpgX
+          BpjhnML5R2giQxHuOF+Zva0wcFqpIFddmB6miM675QjXSr53jTm2toLPUjGi8NeO
+          eSg/QpPHDVSF8f9VKuqah5yR3ZMhasxLpoHMGtqAWtcrNkc7hhrZH7RMVB4en54z
+          qNEotBFBSotbaVJ6F3L1OQKBgGurFnu1Qa647BQs0a/G4CNgL0zVMVBKR7fc/1wR
+          M8GHebpxThvgHAYuZXPkwFumIZ86KL2NwdJZkzSuncKrH0zCAJUhsB84heQA/IaQ
+          OQ9ql6+SHfWDy73jkQDiBx8r6SBgU2G0mv2ZEQOJsCHxdmYbGI+Yna4YCQ5gyaIU
+          jagZAoGAK8uj/kErsP42jrjT0jiwFCRAYdsxqaZYotH/GIjF0pwOgzZw0nxD196Z
+          r8ZGJ8TtbkUybJdIA5a6DPawayIiDfFMFGzYB1Rbds39So3daDLwG625Iy/XLwKL
+          PGmj6PrsJmxY4IJfqLbGFgD9jUu+ZKZ5FmfmvQB+m2eODSsr9Po=
+          -----END RSA PRIVATE KEY-----
+        certificate: |
+          -----BEGIN CERTIFICATE-----
+          MIIEVzCCAz+gAwIBAgIJALO14WHj4newMA0GCSqGSIb3DQEBCwUAMIHAMQswCQYD
+          VQQGEwJVUzELMAkGA1UECAwCQ0ExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xITAf
+          BgNVBAoMGFVBQSBSZWxlYXNlIFNwZWMgVGVzdGluZzEUMBIGA1UECwwLVUFBIFJF
+          TEVBU0UxLDAqBgNVBAMMI2dpdGh1Yi5jb20vY2xvdWRmb3VuZHJ5L3VhYS1yZWxl
+          YXNlMSUwIwYJKoZIhvcNAQkBFhZ1YWEtcmVsZWFzZUBnaXRodWIuY29tMCAXDTE3
+          MDEwMzE2MjcxMVoYDzIxMTYxMjEwMTYyNzExWjCBwDELMAkGA1UEBhMCVVMxCzAJ
+          BgNVBAgMAkNBMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMSEwHwYDVQQKDBhVQUEg
+          UmVsZWFzZSBTcGVjIFRlc3RpbmcxFDASBgNVBAsMC1VBQSBSRUxFQVNFMSwwKgYD
+          VQQDDCNnaXRodWIuY29tL2Nsb3VkZm91bmRyeS91YWEtcmVsZWFzZTElMCMGCSqG
+          SIb3DQEJARYWdWFhLXJlbGVhc2VAZ2l0aHViLmNvbTCCASIwDQYJKoZIhvcNAQEB
+          BQADggEPADCCAQoCggEBALoFBWwuf7gVYo6xHRbucUz++w/IivJDO0DdRNpLXiEs
+          EzKjqtSDk78dz9YtGWQ8qRMIcRw+jP35VY1yTYkSD2HfvMJI01Ch6NH3VV2cZHgH
+          MwDV+WGHJ0lMt87TEDT5wO3I4XuZy/oy/bddy/5zjQTgtRR1XXqoio6RD5t4l2yK
+          daaUbWuVLgNCUxEyrkPYF6k9MChPEBxkXiNTU6QRT5MlEhvqI3qralTNqDoxbafJ
+          WOpxXgVEI351pIbi3s5x9RS6L4tCvVemuMw5N4OgdAPtCeEPwk1tzSVttBJVhpjb
+          HlpQuBSmttAgn9/cd0XFkOJgt25ZJuRr4rCPmuJPvdUCAwEAAaNQME4wHQYDVR0O
+          BBYEFLfbFn7Gz0J0HB/wztQpJngzt7eOMB8GA1UdIwQYMBaAFLfbFn7Gz0J0HB/w
+          ztQpJngzt7eOMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAJea03gj
+          hlljisw0e31Buo/R4b7sH6Hho2klGCFLqqk+yJe5T2R8zmOJ6ygbKT6vnUb6KuDB
+          gIThFoAkMR9OQBPvK/2BB6oLocoQ7vNTnPYqmGKLhI6jPHu6jYxG0LFdFhuKMSAW
+          rsI2hVjobEfjSj8HnEDoXqEwDBpz4hgfNPt/BDrxau3nsDGRyJ3FFBjrQMOb3oKA
+          JXdktdSrILgG0XhvdA5R6cnTmT+xYRUzzkOFmF2lJjQIUIxBhW3xY6O4jgwNBFB3
+          4ioCYqGCr9OdIC6IpnFoxnGyCjwtPzP931wVUbMUZObFGcy7SmqHv8gQP3w5YG2i
+          g8U152rRBEMHBaM=
+          -----END CERTIFICATE-----
+        passphrase: ''
+    socket:
+      connectionManagerTimeout: 10000
+      soTimeout: 10000
+    signMetaData: true
+    signRequest: true
+    wantAssertionSigned: true
+    disableInResponseToCheck: false
+smtp:
+  host: localhost
+  port: 2525
+  auth: false
+  starttls: false
+  sslprotocols: TLSv1.2
+
+servlet:
+  session-store: memory
+  idle-timeout: 1800
+  session-cookie:
+    max-age: -1
+    encode-base64: true
+
+rest:
+  template:
+    timeout: 10000
+    maxTotal: 20
+    maxPerRoute: 5
+    maxKeepAlive: 0
+    validateAfterInactivity: 2000
+    retryCount: 0
+
+cors:
+  enforceSystemZonePolicyInAllZones: true
+csp:
+  script-src:
+    - "'self'"
+global:
+  jwk:
+    oidc-trust:
+      key: "key-value"
+      cert: "cert-value"
+    uaa:
+      key: "uaa-zone-key-value"
+      cert: "uaa-zone-cert-value"

--- a/spec/input/all-properties-set.yml
+++ b/spec/input/all-properties-set.yml
@@ -404,6 +404,8 @@ properties:
         - GET
         - HEAD
     client:
+      redirect_uri:
+        matching_mode: legacy
       secret:
         policy:
           minLength: 8

--- a/spec/input/bosh-lite.yml
+++ b/spec/input/bosh-lite.yml
@@ -98,6 +98,10 @@ properties:
     admin:
       client_secret: admin-secret
     catalina_opts: "-Xmx192m -XX:MaxMetaspaceSize=128m"
+    logging_level: DEBUG
+    client:
+      redirect_uri:
+        matching_mode: legacy
     cc:
       client_secret: cc-secret
     clients:

--- a/spec/input/deprecated-properties-still-work.yml
+++ b/spec/input/deprecated-properties-still-work.yml
@@ -78,6 +78,9 @@ properties:
         -----END CERTIFICATE-----
   uaa:
     url: http://test.uaa.url
+    client:
+      redirect_uri:
+        matching_mode: legacy
     login:
       client_secret: secret
     limitedFunctionality:

--- a/spec/input/test-defaults.yml
+++ b/spec/input/test-defaults.yml
@@ -81,6 +81,10 @@ properties:
           passphrase: ''
   uaa:
     url: http://test.uaa.url
+    logging_level: DEBUG
+    client:
+      redirect_uri:
+        matching_mode: legacy
     login:
       client_secret: secret
     jwt:

--- a/spec/uaa-release.erb_spec.rb
+++ b/spec/uaa-release.erb_spec.rb
@@ -196,6 +196,107 @@ describe 'uaa-release erb generation' do
       end
 
     end
+
+    context 'for a bosh-lite.yml with new security defaults' do
+      let(:input) {'spec/input/bosh-lite.yml'}
+      let(:output_uaa) {'spec/compare/bosh-lite-uaa-defaults.yml'}
+      let(:output_log4j2) {'spec/compare/bosh-lite-log4j2-defaults.properties'}
+
+      before do
+        generated_cf_manifest['properties']['uaa']['client']['redirect_uri']['matching_mode'] = 'exact'
+        generated_cf_manifest['properties']['uaa']['logging_level'] = 'INFO'
+      end
+
+      context 'when uaa.yml.erb is provided' do
+        let(:erb_template) {'../jobs/uaa/templates/config/uaa.yml.erb'}
+
+        it 'matches' do
+          yml_compare(output_uaa, parsed_yaml.to_yaml)
+        end
+      end
+
+      context 'when log4j2.properties.erb is provided' do
+        let(:erb_template) {'../jobs/uaa/templates/config/log4j2.properties.erb'}
+        let(:as_yml) {false}
+
+        it 'matches' do
+          str_compare output_log4j2, parsed_yaml.to_s
+        end
+      end
+    end
+
+    context 'for a all-properties-set.yml with new security defaults' do
+      let(:input) {'spec/input/all-properties-set.yml'}
+      let(:output_uaa) {'spec/compare/all-properties-set-uaa-defaults.yml'}
+      let(:output_log4j2) {'spec/compare/all-properties-set-log4j2-defaults.properties'}
+
+      before do
+        generated_cf_manifest['properties']['uaa']['client']['redirect_uri']['matching_mode'] = 'exact'
+        generated_cf_manifest['properties']['uaa']['logging_level'] = 'INFO'
+      end
+
+      context 'when uaa.yml.erb is provided' do
+        let(:erb_template) {'../jobs/uaa/templates/config/uaa.yml.erb'}
+
+        it 'matches' do
+          yml_compare(output_uaa, parsed_yaml.to_yaml)
+        end
+      end
+
+      context 'when log4j2.properties.erb is provided' do
+        let(:erb_template) {'../jobs/uaa/templates/config/log4j2.properties.erb'}
+        let(:as_yml) {false}
+
+        it 'matches' do
+          str_compare output_log4j2, parsed_yaml.to_s
+        end
+      end
+    end
+
+    context 'for test-defaults.yml with new security defaults' do
+      let(:input) {'spec/input/test-defaults.yml'}
+      let(:output_uaa) {'spec/compare/test-defaults-uaa-defaults.yml'}
+      let(:output_log4j2) {'spec/compare/test-defaults-log4j2-defaults.properties'}
+
+      before do
+        generated_cf_manifest['properties']['uaa']['client']['redirect_uri']['matching_mode'] = 'exact'
+        generated_cf_manifest['properties']['uaa']['logging_level'] = 'INFO'
+      end
+
+      context 'when uaa.yml.erb is provided' do
+        let(:erb_template) {'../jobs/uaa/templates/config/uaa.yml.erb'}
+
+        it 'matches' do
+          yml_compare output_uaa, parsed_yaml.to_yaml
+        end
+      end
+
+      context 'when log4j2.properties.erb is provided' do
+        let(:erb_template) {'../jobs/uaa/templates/config/log4j2.properties.erb'}
+        let(:as_yml) {false}
+
+        it 'matches' do
+          str_compare output_log4j2, parsed_yaml.to_s
+        end
+      end
+    end
+
+    context 'for deprecated-properties-still-work.yml with new security defaults' do
+      let(:input) {'spec/input/deprecated-properties-still-work.yml'}
+      let(:output_uaa) {'spec/compare/deprecated-properties-still-work-uaa-defaults.yml'}
+
+      before do
+        generated_cf_manifest['properties']['uaa']['client']['redirect_uri']['matching_mode'] = 'exact'
+      end
+
+      context 'when uaa.yml.erb is provided' do
+        let(:erb_template) {'../jobs/uaa/templates/config/uaa.yml.erb'}
+
+        it 'matches' do
+          yml_compare output_uaa, parsed_yaml.to_yaml
+        end
+      end
+    end
   end
 
   context 'health_check' do
@@ -674,11 +775,19 @@ describe 'uaa-release erb generation' do
       end
     end
 
-    context 'when set to legacy' do
+    context 'when not explicitly set (pre-fix: input defaults to legacy)' do
       before { generated_cf_manifest['properties']['uaa']['client']['redirect_uri']['matching_mode'] = 'legacy' }
 
       it 'results in allow_unsafe_matching: true' do
         expect(parsed_yaml['uaa']['oauth']['redirect_uri']['allow_unsafe_matching']).to eq(true)
+      end
+    end
+
+    context 'when not set by the user' do
+      before { generated_cf_manifest['properties']['uaa']['client']['redirect_uri']['matching_mode'] = 'exact' }
+
+      it 'defaults to false (exact matching)' do
+        expect(parsed_yaml['uaa']['oauth']['redirect_uri']['allow_unsafe_matching']).to eq(false)
       end
     end
   end
@@ -1493,6 +1602,67 @@ describe 'uaa-release erb generation' do
         end
       end
 
+  end
+
+  describe 'logging formats with new security defaults' do
+      let(:input) {'spec/input/test-defaults.yml'}
+
+      let(:erb_template) {'../jobs/uaa/templates/config/log4j2.properties.erb'}
+      let(:log4j2_template_path) {'spec/compare/default-log4j2-template-defaults.properties'}
+      let(:as_yml) {false}
+
+      let(:generated_cf_manifest) {generate_cf_manifest(input)}
+      let(:parsed_yaml) {read_and_parse_string_template(erb_template, generated_cf_manifest, as_yml)}
+
+      before do
+        generated_cf_manifest['properties']['uaa']['logging_level'] = 'INFO'
+      end
+
+      context 'when uaa.logging.format.timestamp is not set' do
+          it 'uses default value of rfc3339 and sets log_pattern with INFO log level' do
+              log4j2_template = File.read(log4j2_template_path)
+              expected_output_log4j2 = log4j2_template.sub! 'EXPECTED_LOG_PATTERN_PLACEHOLDER', "%d{yyyy-MM-dd'T'HH:mm:ss.nnnnnn}{GMT+0}Z"
+              expect(parsed_yaml.to_s).to eq(expected_output_log4j2)
+          end
+      end
+
+      context 'when uaa.logging.format.timestamp is configured to' do
+          context 'rfc3339' do
+            before do
+              generated_cf_manifest['properties']['uaa']['logging'] = {'format' => {'timestamp' => 'rfc3339'}}
+            end
+
+            it 'sets log_pattern to conform to rfc3339 with INFO log level' do
+                log4j2_template = File.read(log4j2_template_path)
+                expected_output_log4j2 = log4j2_template.sub! 'EXPECTED_LOG_PATTERN_PLACEHOLDER', "%d{yyyy-MM-dd'T'HH:mm:ss.nnnnnn}{GMT+0}Z"
+                expect(parsed_yaml.to_s).to eq(expected_output_log4j2)
+            end
+          end
+
+          context 'rfc3339-legacy' do
+            before do
+              generated_cf_manifest['properties']['uaa']['logging'] = {'format' => {'timestamp' => 'rfc3339-legacy'}}
+            end
+
+            it 'sets log_pattern for rfc3339-legacy format with INFO log level' do
+              log4j2_template = File.read(log4j2_template_path)
+              expected_output_log4j2 = log4j2_template.sub! 'EXPECTED_LOG_PATTERN_PLACEHOLDER', "%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}"
+              expect(parsed_yaml.to_s).to eq(expected_output_log4j2)
+            end
+          end
+
+          context 'deprecated' do
+            before do
+              generated_cf_manifest['properties']['uaa']['logging'] = {'format' => {'timestamp' => 'deprecated'}}
+            end
+
+            it 'sets log_pattern to deprecated format with INFO log level' do
+              log4j2_template = File.read(log4j2_template_path)
+              expected_output_log4j2 = log4j2_template.sub! 'EXPECTED_LOG_PATTERN_PLACEHOLDER', "%d{yyyy-MM-dd HH:mm:ss.SSS}"
+              expect(parsed_yaml.to_s).to eq(expected_output_log4j2)
+            end
+          end
+      end
   end
 
   def self.perform_compare(input)

--- a/spec/uaa-release.erb_spec.rb
+++ b/spec/uaa-release.erb_spec.rb
@@ -674,8 +674,10 @@ describe 'uaa-release erb generation' do
       end
     end
 
-    context 'when not set by the user' do
-      it 'defaults to true' do
+    context 'when set to legacy' do
+      before { generated_cf_manifest['properties']['uaa']['client']['redirect_uri']['matching_mode'] = 'legacy' }
+
+      it 'results in allow_unsafe_matching: true' do
         expect(parsed_yaml['uaa']['oauth']['redirect_uri']['allow_unsafe_matching']).to eq(true)
       end
     end


### PR DESCRIPTION
Changes span the pre-start script, log4j2 redaction pattern, redirect URI matching default, and release tooling.

&nbsp;

**Redirect URI matching (BREAKING CHANGE)**

`uaa.client.redirect_uri.matching_mode` now defaults to `exact` rather than `legacy`. Deployments with clients that use subdomain or path wildcard redirect URIs must register exact URIs or explicitly set `matching_mode: legacy` in their manifest before upgrading.

&nbsp;

**Logging defaults**

`uaa.logging_level` now defaults to `INFO`. The log4j2 redaction pattern is extended to cover `code=`, `access_token=`, `refresh_token=`, and `id_token=` values in addition to `password=` and `client_secret=`.

&nbsp;

**cert-cache file ownership**

`pre-start` now calls `resecure_cert_cache()` after `configure_tomcat` and `configure_spring_boot`, restoring `cert-cache` to `root:root 0711` and its contents to `root:root 0644`. The `vcap` process retains read-only access to the truststore.

&nbsp;

**Release script temp file handling**

`perform-release.sh` now uses `mktemp` for all temporary files and directories, with mode `0600` on credential-bearing files and `trap ... EXIT` for cleanup.