### PR TITLE
Ship acceptance test suite as a BOSH errand; harden truststore tests

### DIFF
--- a/jobs/acceptance-tests/spec
+++ b/jobs/acceptance-tests/spec
@@ -1,0 +1,37 @@
+---
+name: acceptance-tests
+
+# Errand job: runs the uaa-release ginkgo acceptance suite from a VM that
+# the director schedules on the deployment network. Running on-network is
+# deliberate -- the suite shells out to `bosh ssh`/`bosh scp` against the
+# UAA instance and makes HTTP calls to it. From a Concourse worker those
+# went through the bbl SOCKS5 jumpbox and timed out (the suite's scp
+# helpers hardcode a 10s Eventually), and /etc/hosts there is a read-only
+# runc bind mount so the suite's addLocalDNS helper failed with EACCES.
+# A normal BOSH VM on the deployment network has direct line-of-sight to
+# the director/instances (no jumpbox) and a writable /etc/hosts, so both
+# of those bosh-lite-era assumptions in the suite hold again.
+
+templates:
+  run.erb: bin/run
+
+packages:
+- acceptance-tests
+
+properties:
+  bosh.environment:
+    description: "BOSH director URL the suite targets for deploy/ssh/scp (e.g. https://10.0.0.6:25555)."
+  bosh.client:
+    description: "BOSH director client (username) the suite authenticates with."
+  bosh.client_secret:
+    description: "BOSH director client secret."
+  bosh.ca_cert:
+    description: "PEM contents of the BOSH director CA certificate. Materialised to a file because the suite reads BOSH_CA_CERT as a path."
+  bosh.deployment:
+    description: "Name of the UAA deployment the suite deploys/targets. Exported as BOSH_DEPLOYMENT; the suite has no hardcoded deployment name."
+  bosh.all_proxy:
+    description: "Jumpbox SOCKS5 endpoint (ssh+socks5://jumpbox@host:port, no private-key query). The director's :25555 is firewalled to the jumpbox, so the suite reaches it via this proxy. run.erb appends ?private-key=<file> after materialising the key."
+  bosh.jumpbox_private_key:
+    description: "PEM contents of the jumpbox SSH private key. Materialised to a file referenced by BOSH_ALL_PROXY."
+  uaa_deployment_manifest_b64:
+    description: "Base64 of the rendered UAA deployment manifest. Base64 so BOSH does not try to resolve the manifest's own ((vars)) against the errand deployment when it interpolates the errand manifest. run.erb decodes it to /tmp/uaa-deployment.yml; the suite (re)deploys from that exact path per scenario and resolves the ((vars)) itself via its --vars-store."

--- a/jobs/acceptance-tests/templates/run.erb
+++ b/jobs/acceptance-tests/templates/run.erb
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Errand entrypoint for the uaa-release acceptance suite. BOSH renders
+# this ERB (substituting the director credentials and the rendered UAA
+# manifest), copies it to /var/vcap/jobs/acceptance-tests/bin/run, and
+# runs it as root on a VM the director places on the deployment network.
+#
+# Running here -- rather than from the Concourse worker -- is the whole
+# point of the errand: it is in-region, so `bosh ssh`/`bosh scp` through
+# the jumpbox and the HTTP calls to the UAA instance are LAN-fast and the
+# suite's hardcoded 10s scp Eventually passes, and /etc/hosts is a normal
+# writable file (so the suite's addLocalDNS helper works).
+
+set -euo pipefail
+
+PKG=/var/vcap/packages/acceptance-tests
+RUN_DIR=/var/vcap/data/acceptance-tests
+mkdir -p "${RUN_DIR}"
+
+# The BOSH agent runs errands with no $HOME; the bosh CLI needs it to
+# create ~/.bosh (else: "Getting current user home dir: $HOME is not
+# defined"). Point it at our writable data dir.
+export HOME="${RUN_DIR}"
+
+# The suite reads BOSH_CA_CERT as a *path* (it os.ReadFile()s it), so
+# materialise the cert contents to a file. Quoted heredoc: ERB has
+# already substituted the cert text; the quotes stop the shell from
+# mangling it.
+CA_CERT_FILE="${RUN_DIR}/bosh-ca.pem"
+cat > "${CA_CERT_FILE}" <<'EOF_BOSH_CA_CERT'
+<%= p('bosh.ca_cert') %>
+EOF_BOSH_CA_CERT
+
+export BOSH_ENVIRONMENT="<%= p('bosh.environment') %>"
+export BOSH_CLIENT="<%= p('bosh.client') %>"
+export BOSH_CLIENT_SECRET="<%= p('bosh.client_secret') %>"
+export BOSH_CA_CERT="${CA_CERT_FILE}"
+export BOSH_DEPLOYMENT="<%= p('bosh.deployment') %>"
+
+# The suite builds a BOSH SDK client from BOSH_DIRECTOR_IP (bbl print-env
+# does not set it); derive it from the director URL host.
+director_host="${BOSH_ENVIRONMENT#http*://}"
+export BOSH_DIRECTOR_IP="${director_host%%:*}"
+
+# The director's :25555 is firewalled to the jumpbox, so even from this
+# on-network VM we must reach it through the jumpbox SOCKS5 proxy.
+# Materialise the jumpbox key and point BOSH_ALL_PROXY at it. Quoted
+# heredoc: ERB has already substituted the key; the quotes keep the
+# shell from mangling it.
+JUMPBOX_KEY_FILE="${RUN_DIR}/jumpbox.key"
+cat > "${JUMPBOX_KEY_FILE}" <<'EOF_JUMPBOX_KEY'
+<%= p('bosh.jumpbox_private_key') %>
+EOF_JUMPBOX_KEY
+chmod 600 "${JUMPBOX_KEY_FILE}"
+export BOSH_ALL_PROXY="<%= p('bosh.all_proxy') %>?private-key=${JUMPBOX_KEY_FILE}"
+
+# The suite (re)deploys from this exact path per scenario. The manifest
+# is delivered base64-encoded so BOSH never sees its inner ((vars)) when
+# it interpolates THIS errand deployment; decode it back verbatim here
+# (its ((vars)) are resolved later by the suite's own --vars-store).
+printf '%s' '<%= p('uaa_deployment_manifest_b64') %>' | base64 -d > /tmp/uaa-deployment.yml
+
+# Silence the v1.16.5 "Ginkgo 2.0 is coming soon!" banner.
+export ACK_GINKGO_RC=true
+
+# Our bosh CLI ships in the package; the suite shells out to `bosh`.
+export PATH="${PKG}:${PATH}"
+
+# The suite reads opsfiles via "./opsfiles/..." relative to its working
+# directory, so run from the package dir where they were unpacked.
+cd "${PKG}"
+
+# acceptance_tests.test is the ginkgo v1 suite compiled in CI (go test
+# -c). A compiled v1 binary exposes the runtime flags under the -ginkgo.
+# prefix. The old task used the ginkgo CLI:
+#   ginkgo -v --progress --trace -keepGoing -randomizeAllSpecs -randomizeSuites -r .
+# but -r/-keepGoing/-randomizeSuites are CLI-only multi-suite concepts
+# and are NOT registered on a single compiled binary -- passing them
+# would abort with "flag provided but not defined". They are also moot
+# here: this is one suite, and ginkgo already runs every spec regardless
+# of failures unless -ginkgo.failFast is set (it is not). So the set
+# below is the faithful single-binary equivalent.
+exec ./acceptance_tests.test \
+  -ginkgo.v \
+  -ginkgo.progress \
+  -ginkgo.trace \
+  -ginkgo.randomizeAllSpecs

--- a/packages/acceptance-tests/packaging
+++ b/packages/acceptance-tests/packaging
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e -x
+
+# Thin package: the heavy lifting (compiling the ginkgo suite with the Go
+# toolchain, and fetching its modules) is done in CI -- see uaa-ci's
+# shared/tasks/uaa-release-acceptance-tests/task.sh -- which assembles a
+# single tarball and `bosh add-blob`s it as "acceptance-tests.tgz". The
+# tarball contains, at its top level:
+#   acceptance_tests.test  (the ginkgo v1 suite, go-test-compiled, static)
+#   bosh                   (the bosh CLI the suite shells out to)
+#   opsfiles/              (the suite's scenario ops files)
+# so on the compilation VM we only have to unpack it -- no Go, no network.
+
+cd "${BOSH_INSTALL_TARGET}"
+
+tgz="$(find "${BOSH_COMPILE_TARGET}" -name 'acceptance-tests.tgz' | sort | tail -n1)"
+if [[ -z "${tgz}" ]]; then
+  echo "acceptance-tests.tgz blob not found under ${BOSH_COMPILE_TARGET}" >&2
+  exit 1
+fi
+
+tar zxvf "${tgz}" -C "${BOSH_INSTALL_TARGET}"
+
+chmod +x "${BOSH_INSTALL_TARGET}/acceptance_tests.test" "${BOSH_INSTALL_TARGET}/bosh"

--- a/packages/acceptance-tests/spec
+++ b/packages/acceptance-tests/spec
@@ -1,0 +1,5 @@
+---
+name: acceptance-tests
+dependencies:
+files:
+- acceptance-tests.tgz

--- a/src/acceptance_tests/acceptance_tests_suite_test.go
+++ b/src/acceptance_tests/acceptance_tests_suite_test.go
@@ -34,15 +34,19 @@ var (
 	directorClient       string
 	directorClientSecret string
 
+	// No "-d uaa": the deployment is taken from $BOSH_DEPLOYMENT so the
+	// suite operates on whatever deployment the caller targets (e.g. a
+	// build-unique name on a shared director) rather than a hardcoded
+	// "uaa" that would collide with cf-deployment's own uaa.
 	deployCmd = []string{"-n", "deploy", "/tmp/uaa-deployment.yml", "-o", "./opsfiles/enable-local-uaa.yml", "--vars-store=/tmp/uaa-store.json", "-v", "system_domain=localhost"}
-	deleteCmd = []string{"-n", "delete-deployment", "-d", "uaa"}
+	deleteCmd = []string{"-n", "delete-deployment"}
 )
 
 var _ = BeforeSuite(func() {
 	setBoshEnvironmentVariables()
 
 	By("disabling bosh resurrection", func() {
-		disableResurrectionCmd := exec.Command(boshBinaryPath, "-d", "uaa", "update-resurrection", "-n", "off")
+		disableResurrectionCmd := exec.Command(boshBinaryPath, "-d", os.Getenv("BOSH_DEPLOYMENT"), "update-resurrection", "-n", "off")
 		session, err := gexec.Start(disableResurrectionCmd, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(session, 5*time.Minute).Should(gexec.Exit(0))

--- a/src/acceptance_tests/uaa-release_test.go
+++ b/src/acceptance_tests/uaa-release_test.go
@@ -45,10 +45,10 @@ var _ = Describe("UaaRelease", func() {
 
 		expectedNumberOfCerts := len(caCertificatesPemEncodedMap) + numberOfCertsInUaaDockerDeploymentYml
 
-		countNumberOfCerts := runCommandOnUaaViaSsh("/var/vcap/packages/uaa/jdk/bin/keytool -list -storepass 'changeit' -keystore /var/vcap/data/uaa/cert-cache/cacerts")
+		countNumberOfCerts := runCommandOnUaaViaSsh("sudo /var/vcap/packages/uaa/jdk/bin/keytool -list -storepass 'changeit' -keystore /var/vcap/data/uaa/cert-cache/cacerts")
 		Expect(countNumberOfCerts).To(ContainSubstring("Your keystore contains " + strconv.Itoa(expectedNumberOfCerts) + " entries"))
 
-		uaaTrustStoreFingerprints := runCommandOnUaaViaSsh("/var/vcap/packages/uaa/jdk/bin/keytool  -keystore /var/vcap/data/uaa/cert-cache/cacerts -storepass 'changeit' -list  | grep 'Certificate fingerprint'| cut -d ' ' -f 4 ")
+		uaaTrustStoreFingerprints := runCommandOnUaaViaSsh("sudo /var/vcap/packages/uaa/jdk/bin/keytool  -keystore /var/vcap/data/uaa/cert-cache/cacerts -storepass 'changeit' -list  | grep 'Certificate fingerprint'| cut -d ' ' -f 4 ")
 
 		for certificate := range caCertificatesPemEncodedMap {
 			fingerprint, err := getFingerPrint([]byte(certificate))
@@ -60,6 +60,65 @@ var _ = Describe("UaaRelease", func() {
 		Eventually(verifyTomcatIsUsingCorrectTruststore(),
 			5*time.Minute,
 			10*time.Second).Should(BeTrue())
+	})
+
+	Context("hardens the on-disk truststore against symlink attacks", func() {
+		BeforeEach(func() {
+			deployUAA()
+		})
+
+		It("locks down cert-cache to 0700 vcap:vcap so only the uaa process can read it", func() {
+			statOutput := runCommandOnUaaViaSsh("sudo stat -c '%a %U:%G' /var/vcap/data/uaa/cert-cache")
+			Expect(strings.TrimSpace(statOutput)).To(Equal("700 vcap:vcap"))
+		})
+
+		It("replaces a pre-planted symlink at cert-cache with a real directory on next pre-start", func() {
+			// Threat model: an attacker with vcap-level access (a compromised
+			// UAA process) plants a symlink at cert-cache before the next
+			// pre-start runs. Without the defense in ensure_persistent_cert_dir_secure,
+			// pre-start would run as root and follow the symlink, writing
+			// keystore material into the attacker-chosen target.
+			runCommandOnUaaViaSsh(strings.Join([]string{
+				"sudo rm -rf /tmp/canary-dir",
+				"sudo mkdir -p /tmp/canary-dir",
+				"echo untouched | sudo tee /tmp/canary-dir/sentinel > /dev/null",
+				"sudo rm -rf /var/vcap/data/uaa/cert-cache",
+				"sudo ln -s /tmp/canary-dir /var/vcap/data/uaa/cert-cache",
+				"sudo /var/vcap/jobs/uaa/bin/pre-start > /dev/null 2>&1",
+			}, " && "))
+			defer runCommandOnUaaViaSsh("sudo rm -rf /tmp/canary-dir")
+
+			kind := runCommandOnUaaViaSsh("sudo test -L /var/vcap/data/uaa/cert-cache && echo LINK || echo DIR")
+			Expect(strings.TrimSpace(kind)).To(Equal("DIR"))
+
+			listing := runCommandOnUaaViaSsh("sudo ls /tmp/canary-dir")
+			Expect(strings.TrimSpace(listing)).To(Equal("sentinel"))
+
+			sentinel := runCommandOnUaaViaSsh("sudo cat /tmp/canary-dir/sentinel")
+			Expect(strings.TrimSpace(sentinel)).To(Equal("untouched"))
+		})
+
+		It("does not follow vcap-planted symlinks for individual cache files on next pre-start", func() {
+			// Threat model: vcap can write inside cert-cache (which is
+			// 0700 vcap:vcap after configure_tomcat). An attacker replaces
+			// one of the cache files with a symlink to a privileged path;
+			// without the rm -f before cp in save_new_cache_files_to_persistent_disk,
+			// pre-start's cp would follow the symlink and overwrite the
+			// attacker-chosen target.
+			runCommandOnUaaViaSsh(strings.Join([]string{
+				"sudo rm -f /tmp/canary-file",
+				"echo untouched | sudo tee /tmp/canary-file > /dev/null",
+				"sudo ln -sf /tmp/canary-file /var/vcap/data/uaa/cert-cache/os-certs-cache.txt",
+				"sudo /var/vcap/jobs/uaa/bin/pre-start > /dev/null 2>&1",
+			}, " && "))
+			defer runCommandOnUaaViaSsh("sudo rm -f /tmp/canary-file")
+
+			canary := runCommandOnUaaViaSsh("sudo cat /tmp/canary-file")
+			Expect(strings.TrimSpace(canary)).To(Equal("untouched"))
+
+			kind := runCommandOnUaaViaSsh("sudo test -L /var/vcap/data/uaa/cert-cache/os-certs-cache.txt && echo LINK || echo FILE")
+			Expect(strings.TrimSpace(kind)).To(Equal("FILE"))
+		})
 	})
 
 	XContext("UAA consuming the `database` link", func() {
@@ -112,7 +171,7 @@ var _ = Describe("UaaRelease", func() {
 			deployUAA("./opsfiles/two-db-instances.yml")
 
 			By("stopping the first DB instance", func() {
-				cmd := exec.Command(boshBinaryPath, "-d", "uaa", "stop", "-n", "database/0")
+				cmd := exec.Command(boshBinaryPath, "-d", os.Getenv("BOSH_DEPLOYMENT"), "stop", "-n", "database/0")
 				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(session, 5*time.Minute).Should(gexec.Exit(0))


### PR DESCRIPTION
Adds the bits the uaa-ci uaa-bosh-release-test job needs to run the existing ginkgo acceptance suite as a BOSH errand on the shared bbl- managed director, rather than from a Concourse worker inside a start-bosh container. (The worker approach broke two suite assumptions: the 10s `bosh scp` Eventually is blown by the bbl SOCKS5 jumpbox round trip, and addLocalDNS opens /etc/hosts O_RDWR which fails EACCES on the runc bind mount.)

New errand job: jobs/acceptance-tests
  - run.erb wires up BOSH env/proxy, decodes the UAA manifest the CI task passes in base64, and execs the compiled ginkgo binary.
  - spec declares the bosh + uaa_deployment_manifest_b64 properties; monit is empty (errand convention).

New package: packages/acceptance-tests
  - unpacks acceptance-tests.tgz (compiled ginkgo binary + bosh CLI + opsfiles, supplied by uaa-ci via bosh add-blob).

Suite changes (src/acceptance_tests):
  - acceptance_tests_suite_test.go: drop hardcoded "-d uaa" so the delete and disable-resurrection commands target $BOSH_DEPLOYMENT (the errand passes a build-unique name to avoid colliding with cf-deployment's own uaa deployment on the shared director).
  - uaa-release_test.go: run the two keytool reads in the truststore spec under sudo. /var/vcap/data/uaa/cert-cache is intentionally locked to 0700 vcap:vcap by the pre-start hardening from cd935d03; a bosh-ssh ephemeral user is in the vcap group but not the owner, so it cannot traverse the dir without sudo. Operators inspecting a locked-down truststore would use sudo; the test should too.

New tests (src/acceptance_tests/uaa-release_test.go):
  Three end-to-end tests for the pre-start cert-cache hardening that
  previously had no coverage:
    1. cert-cache is 0700 vcap:vcap after deploy.
    2. A pre-planted symlink at cert-cache is replaced with a real directory on next pre-start (covers ensure_persistent_cert_dir _secure's symlink-detection branch).
    3. Pre-planted symlinks for individual cache files are not followed by pre-start's cp (covers the rm -f before cp in save_new_cache_files_to_persistent_disk).