### PR TITLE
improve startup scripts and logs take 2

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -203,7 +203,7 @@ properties:
     description: "The url to use as the issuer URI"
   uaa.logging_level:
     description: Set UAA logging level.  (e.g. TRACE, DEBUG, INFO)
-    default: DEBUG
+    default: INFO
   uaa.logging.format.timestamp:
     description: "Format for timestamp in component logs. Valid values are 'rfc3339', 'rfc3339-legacy', and 'deprecated'. 'rfc3339' sets the format to be {yyyy-MM-dd'T'HH:mm:ss.nnnnnn}{GMT+0}Z which is rfc3339 compliant but additionally has microsecond precision and is set to UTC timezone. 'rfc3339-legacy' sets the time format to be yyyy-MM-dd'T'HH:mm:ss.SSSXXX. 'deprecated' sets the time format to be yyyy-MM-dd HH:mm:ss.SSS."
     default: rfc3339
@@ -580,7 +580,10 @@ properties:
       When set to `legacy`, allow unsafe matching of redirect URIs.
       For example, https://example.com would also match all subdomains and all paths of https://example.com.
       When set to `exact`, will provide OAuth2 spec-compliant (RFC6749) exact redirect URI matching.
-    default: legacy
+      NOTE: changing this from `legacy` to `exact` is a breaking change for clients that rely on
+      wildcard or subdomain redirect URI matching. Review all registered client redirect URIs before
+      enabling `exact` mode in existing deployments.
+    default: exact
 
   # Clients
   uaa.clients:

--- a/jobs/uaa/templates/bin/pre-start.erb
+++ b/jobs/uaa/templates/bin/pre-start.erb
@@ -176,6 +176,17 @@ function configure_tomcat {
     chown -R vcap:vcap /var/vcap/data/uaa/
 }
 
+function resecure_cert_cache {
+    # configure_tomcat hands all of /var/vcap/data/uaa/ to vcap via chown -R.
+    # Re-secure cert-cache so that the vcap process cannot tamper with the
+    # truststore between deploys. vcap retains read-only access via the
+    # execute bit on the directory and world-readable mode on the files.
+    chown root:root "${PERSISTENT_CERTS_DIR}"
+    chmod 0711 "${PERSISTENT_CERTS_DIR}"
+    find "${PERSISTENT_CERTS_DIR}" -maxdepth 1 -type f -exec chown root:root {} +
+    find "${PERSISTENT_CERTS_DIR}" -maxdepth 1 -type f -exec chmod 0644 {} +
+}
+
 function configure_spring_boot {
     # When run with bpm, the vcap user does not have permissions to read
     # files in the jobs and packages directories. Consequently, we move
@@ -212,6 +223,8 @@ process_certs
 configure_tomcat
 
 configure_spring_boot
+
+resecure_cert_cache
 
 rm -rf $TMP_DIR
 

--- a/jobs/uaa/templates/config/log4j2.properties.erb
+++ b/jobs/uaa/templates/config/log4j2.properties.erb
@@ -15,7 +15,7 @@ case logging_format_timestamp_value
 end
 %>
 property.log_directory = /var/vcap/sys/log/uaa
-property.log_pattern=[<%= timestamp_format %>] uaa%X{context} - %pid [%t] - [%X{traceId},%X{spanId}] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=)([^&]*)}{<redacted>}%n
+property.log_pattern=[<%= timestamp_format %>] uaa%X{context} - %pid [%t] - [%X{traceId},%X{spanId}] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=|code=|access_token=|refresh_token=|id_token=)([^&\s]*)}{<redacted>}%n
 
 appender.uaaDefaultAppender.type = File
 appender.uaaDefaultAppender.name = UaaDefaultAppender

--- a/scripts/perform-release.sh
+++ b/scripts/perform-release.sh
@@ -7,8 +7,7 @@ CYAN='\033[0;36m'
 BOLD='\033[0;1m'
 NC='\033[0m' # No Color
 
-TMPDIR=/tmp
-SAVEDIR=$TMPDIR/uaa-release-save
+SAVEDIR=$(mktemp -d)
 RELEASES=$SAVEDIR/releases
 FINAL_BUILDS=$SAVEDIR/.final_builds
 
@@ -123,12 +122,16 @@ git fetch --all --prune > /dev/null
 
 echo -e "${CYAN}Creating bosh UAA-release ${GREEN} ${1} ${NC} using `bosh -v`"
 
-# we save private.yml to a temp directory
-# just in case it gets deleted during branch switch
+# we save private.yml to a secure temp file so it survives branch switches
+# and is cleaned up automatically on exit.
+PRIVATE_YML_COPY=$(mktemp)
+chmod 0600 "${PRIVATE_YML_COPY}"
+trap 'rm -f "${PRIVATE_YML_COPY}"' EXIT
+
 if [ "$#" -ge 3 ]; then
-    cp $3 /tmp/private.yml
+    cp "$3" "${PRIVATE_YML_COPY}"
 elif [ -f config/private.yml ]; then
-    cp config/private.yml /tmp/private.yml
+    cp config/private.yml "${PRIVATE_YML_COPY}"
 else
     echo -e "${RED}ERROR:${NC} Missing private.yml file" >&2
     usage
@@ -140,7 +143,7 @@ git checkout $branch_to_release_from
 sub_update
 
 # restore private.yml in case it got deleted
-cp /tmp/private.yml config/
+cp "${PRIVATE_YML_COPY}" config/
 
 echo -e "${CYAN}Building tarball ${GREEN}${1}${NC} and tag with ${GREEN}v${1}${NC}"
 # create a release tar ball - and a dev release


### PR DESCRIPTION
Override PR https://github.com/cloudfoundry/uaa-release/pull/1236 as no checks were run

Changes span the pre-start script, log4j2 redaction pattern, redirect URI matching default, and release tooling.

&nbsp;

**Redirect URI matching (BREAKING CHANGE)**

`uaa.client.redirect_uri.matching_mode` now defaults to `exact` rather than `legacy`. Deployments with clients that use subdomain or path wildcard redirect URIs must register exact URIs or explicitly set `matching_mode: legacy` in their manifest before upgrading.

&nbsp;

**Logging defaults**

`uaa.logging_level` now defaults to `INFO`. The log4j2 redaction pattern is extended to cover `code=`, `access_token=`, `refresh_token=`, and `id_token=` values in addition to `password=` and `client_secret=`.

&nbsp;

**cert-cache file ownership**

`pre-start` now calls `resecure_cert_cache()` after `configure_tomcat` and `configure_spring_boot`, restoring `cert-cache` to `root:root 0711` and its contents to `root:root 0644`. The `vcap` process retains read-only access to the truststore.

&nbsp;

**Release script temp file handling**

`perform-release.sh` now uses `mktemp` for all temporary files and directories, with mode `0600` on credential-bearing files and `trap ... EXIT` for cleanup.