### PR TITLE
feat(spiffe): wire uaa.spiffe.* for JWT-SVID signer (RFC UAA-SPIFFE-001)

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -737,6 +737,21 @@ properties:
     description: "The format for the refresh token. Allowed values are `jwt`, `opaque`"
     default: jwt
 
+  # SPIFFE workload identity (Plan A signer). Setting uaa.spiffe.instance_identity_ca activates the JWT-SVID signer endpoint.
+  uaa.spiffe.trust_domain:
+    description: "The SPIFFE trust domain for issued JWT-SVIDs (e.g. the CF deployment domain)."
+  uaa.spiffe.instance_identity_ca:
+    description: "PEM-encoded Diego instance identity CA certificate. When set, the SPIFFE JWT-SVID signer endpoint is activated; leave unset to keep SPIFFE disabled."
+  uaa.spiffe.jwt_svid_ttl_seconds:
+    description: "Validity in seconds of issued JWT-SVIDs."
+    default: 3600
+  uaa.spiffe.pop_freshness_seconds:
+    description: "Maximum age in seconds of a proof-of-possession challenge before it is rejected."
+    default: 60
+  uaa.spiffe.pop_enabled:
+    description: "Set to false to disable proof-of-possession verification on JWT-SVID requests."
+    default: true
+
   # cors settings
   uaa.cors.default.allowed.headers:
     description: "whitelist for allowed headers for non-xhr cors requests"

--- a/jobs/uaa/templates/config/uaa.yml.erb
+++ b/jobs/uaa/templates/config/uaa.yml.erb
@@ -870,6 +870,18 @@
     end
   end
 
+  # SPIFFE workload identity (Plan A signer); activated only when the instance identity CA is provided.
+  if_p('uaa.spiffe.instance_identity_ca') do |ca|
+    spiffe = {
+      'trust_domain' => p('uaa.spiffe.trust_domain'),
+      'instance_identity_ca' => ca,
+      'jwt_svid_ttl_seconds' => p('uaa.spiffe.jwt_svid_ttl_seconds'),
+      'pop_freshness_seconds' => p('uaa.spiffe.pop_freshness_seconds'),
+      'pop_enabled' => p('uaa.spiffe.pop_enabled')
+    }
+    add_value(params, spiffe, 'uaa', 'spiffe')
+  end
+
 
   #validate that we have all required parameters
 


### PR DESCRIPTION
## Summary

Exposes the BOSH job configuration UAA needs to run as a SPIFFE identity server,
and bumps the `uaa` submodule to the `spiffe-signer` branch that adds the JWT-SVID
signing endpoint.

## Key changes
- `jobs/uaa/spec` + `jobs/uaa/templates/config/uaa.yml.erb`: new `uaa.spiffe.*`
  properties (`trust_domain`, `instance_identity_ca`) consumed by the signer.
- `src/uaa` submodule → `spiffe-signer` (JWT-SVID endpoint, DTOs, instance-identity
  CA bean, security-chain wiring).

## Context
Part of **RFC UAA-SPIFFE-001** — *UAA as a SPIFFE Identity Server for Cloud Foundry*.

## Cross-repo dependencies
- **cloudfoundry/uaa** `spiffe-signer` (referenced submodule)
- **cloudfoundry/diego-release** `spiffe-agent` — the SPIFFE Agent that calls the
  signing endpoint.

## Status
Draft / POC. End-to-end verified on bosh-lite.
