### PR TITLE
Enable PR creation in upgrade workflows for Java and Tomcat.

### DIFF
--- a/.github/workflows/upgrade-java.yml
+++ b/.github/workflows/upgrade-java.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Check Java Version
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           java_major_version=${{ matrix.java }}
           binary_metadata_url="https://api.bell-sw.com/v1/liberica/releases?version-modifier=latest"
@@ -89,6 +89,12 @@ jobs:
           git status
 
           BRANCH_NAME="Java-${JDK_VERSION}"
+
+          if [[ -n "$(gh pr list --head "${BRANCH_NAME}" --state open --json number --jq '.[0].number')" ]]; then
+            echo "## ☑️ PR already open for ${BRANCH_NAME}" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
           git checkout -b "${BRANCH_NAME}"
           git commit -m "Upgrade Bellsoft JDK to version ${JDK_VERSION}"
           git push -u origin "${BRANCH_NAME}"

--- a/.github/workflows/upgrade-java.yml
+++ b/.github/workflows/upgrade-java.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      pull-requests: write
     strategy:
       matrix:
         java: [ '25' ]
@@ -86,8 +87,12 @@ jobs:
           git status
           git add config/blobs.yml
           git status
-          
+
+          BRANCH_NAME="Java-${JDK_VERSION}"
+          git checkout -b "${BRANCH_NAME}"
           git commit -m "Upgrade Bellsoft JDK to version ${JDK_VERSION}"
-          git push
-          
+          git push -u origin "${BRANCH_NAME}"
+
           echo "✅ Committed $(git log -n 1 --graph --pretty='%Cred%h%Creset - %s%Creset' | sed 's/^.//')" >> $GITHUB_STEP_SUMMARY
+
+          gh pr create --title "Upgrade Bellsoft JDK to version ${JDK_VERSION}" --body "Automated upgrade of Bellsoft JDK to version ${JDK_VERSION}."

--- a/.github/workflows/upgrade-tomcat.yml
+++ b/.github/workflows/upgrade-tomcat.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      pull-requests: write
     strategy:
       matrix:
         tomcat: [ '11' ]
@@ -45,6 +46,7 @@ jobs:
       - name: Check Tomcat Version
         env:
           TOMCAT_VERSION: ${{ matrix.tomcat }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TOMCAT_INDEX_URL=${TOMCAT_BASE_URL}/tomcat-${TOMCAT_VERSION}
           tomcat_versions="$(curl -sSfL "${TOMCAT_INDEX_URL}" \
@@ -88,9 +90,13 @@ jobs:
           git status
           git add config/blobs.yml
           git status
-          
+
+          BRANCH_NAME="Tomcat-${LATEST_TOMCAT_VERSION}"
+          git checkout -b "${BRANCH_NAME}"
           git commit -m "Upgrade Tomcat to version $LATEST_TOMCAT_VERSION"
-          git push
-          
+          git push -u origin "${BRANCH_NAME}"
+
           commit_id=$(git log -n 1 --graph --pretty='%Cred%h%Creset - %s%Creset' | sed 's/^.//')
           echo "✅ Committed ${commit_id}" >> $GITHUB_STEP_SUMMARY
+
+          gh pr create --title "Upgrade Tomcat to version ${LATEST_TOMCAT_VERSION}" --body "Automated upgrade of Tomcat to version ${LATEST_TOMCAT_VERSION}."

--- a/.github/workflows/upgrade-tomcat.yml
+++ b/.github/workflows/upgrade-tomcat.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Check Tomcat Version
         env:
           TOMCAT_VERSION: ${{ matrix.tomcat }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TOMCAT_INDEX_URL=${TOMCAT_BASE_URL}/tomcat-${TOMCAT_VERSION}
           tomcat_versions="$(curl -sSfL "${TOMCAT_INDEX_URL}" \
@@ -92,6 +92,12 @@ jobs:
           git status
 
           BRANCH_NAME="Tomcat-${LATEST_TOMCAT_VERSION}"
+
+          if [[ -n "$(gh pr list --head "${BRANCH_NAME}" --state open --json number --jq '.[0].number')" ]]; then
+            echo "## ☑️ PR already open for ${BRANCH_NAME}" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
           git checkout -b "${BRANCH_NAME}"
           git commit -m "Upgrade Tomcat to version $LATEST_TOMCAT_VERSION"
           git push -u origin "${BRANCH_NAME}"


### PR DESCRIPTION

Fix #1262


⏺ Both workflows now create a feature branch (Java-<version>  
or Tomcat-<version>) and open a PR instead of pushing       
directly:

- upgrade-java.yml: added pull-requests: write permission,  
  creates branch Java-${JDK_VERSION}, pushes it, then runs gh
  pr create.
- upgrade-tomcat.yml: added pull-requests: write permission,
  added GITHUB_TOKEN to the step's env (needed for gh),       
  creates branch Tomcat-${LATEST_TOMCAT_VERSION}, pushes it,  
  then runs gh pr create.

PR base is left unset so gh defaults to the repo's default  
branch, matching whatever ref the scheduled workflow checked
out.                    