### PR TITLE
feat: RFC 8705 mutual-TLS client authentication — BOSH release changes

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -1308,12 +1308,8 @@ properties:
             -----END CERTIFICATE----
 
   uaa.mtls_enabled:
-    description: "Enable the RFC 8705 mTLS token endpoint at uaa.mtls_endpoint_path. Requires Gorouter forwarded_client_cert: sanitize_set."
+    description: "Enable RFC 8705 mTLS client authentication at /oauth/mtls/token. Requires Gorouter forwarded_client_cert: sanitize_set."
     default: false
-
-  uaa.mtls_endpoint_path:
-    description: "Path for the mTLS token endpoint"
-    default: "/oauth/mtls/token"
   login.saml.providers:
     description: |
       Contains a hash of SAML Identity Providers,

--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -1304,8 +1304,16 @@ properties:
       BTADAQH/MA0GCSqGSIb3DQEBBQUAA4GBAL5j1JCN5EoXMOOBSBUL8KeVZFQD3Nfy
       YkYKBatFEKdBFlAKLBdG+5KzE7sTYesn7EzBISHXFz3DhdK2tg+IF1DeSFVmFl2n
       iVxQ1sYjo4kCugHBsWo+MpFH9VBLFzsMlP3eIDuVKe8aPXFKYCGhctZEJdQTKlja
-      lshe50nayKrT
-      -----END CERTIFICATE----
+            lshe50nayKrT
+            -----END CERTIFICATE----
+
+  uaa.mtls_enabled:
+    description: "Enable the RFC 8705 mTLS token endpoint at uaa.mtls_endpoint_path. Requires Gorouter forwarded_client_cert: sanitize_set."
+    default: false
+
+  uaa.mtls_endpoint_path:
+    description: "Path for the mTLS token endpoint"
+    default: "/oauth/mtls/token"
   login.saml.providers:
     description: |
       Contains a hash of SAML Identity Providers,

--- a/jobs/uaa/templates/config/uaa.yml.erb
+++ b/jobs/uaa/templates/config/uaa.yml.erb
@@ -879,3 +879,7 @@
 
 %>
 <%= render(params) %>
+<% if p("uaa.mtls_enabled") %>
+mtls:
+  endpoint: <%= p("uaa.mtls_endpoint_path") %>
+<% end %>

--- a/jobs/uaa/templates/config/uaa.yml.erb
+++ b/jobs/uaa/templates/config/uaa.yml.erb
@@ -380,7 +380,7 @@
       if is_missing(client_data, 'authorized-grant-types')
         message = message + "\nMissing property: uaa.clients.#{id}.authorized-grant-types"
       else
-        message = message + "\nMissing property: uaa.clients.#{id}.secret" if client_data['secret'].nil? && client_data['authorized-grant-types'] != 'implicit'
+        message = message + "\nMissing property: uaa.clients.#{id}.secret" if client_data['secret'].nil? && client_data['authorized-grant-types'] != 'implicit' && client_data['token-endpoint-auth-method'] != 'tls_client_auth' && client_data['token-endpoint-auth-method'] != 'private_key_jwt'
         if (client_data['redirect-uri'].nil? || client_data['redirect-uri'].empty?)
           message = message + "\nMissing property: uaa.clients.#{id}.redirect-uri" if client_data['authorized-grant-types'] =~ /implicit|authorization_code/
         elsif client_data['redirect-uri'].split(',').any? { |uri| !(uri =~ /^http(\*|s)?:\/\/(.*:.*@)?(([a-zA-Z0-9\-\*]+\.)*[a-zA-Z0-9\-]+\.)?[a-zA-Z0-9\-]+(:[0-9]+)?(\/.*|$)/) }

--- a/jobs/uaa/templates/config/uaa.yml.erb
+++ b/jobs/uaa/templates/config/uaa.yml.erb
@@ -369,6 +369,10 @@
       client.each do |key,value|
         client_data[key] = value
       end
+      has_mtls_ca = client_data['tls-client-auth-ca'].is_a?(String) &&
+          !client_data['tls-client-auth-ca'].strip.empty?
+      message = message + "\nInvalid property: uaa.clients.#{id}.token-endpoint-auth-method" unless
+          client_data['token-endpoint-auth-method'].nil?
       if !client['scopes'].nil?
         client_data.delete('scopes')
         if client['scopes'].is_a? Array
@@ -380,7 +384,10 @@
       if is_missing(client_data, 'authorized-grant-types')
         message = message + "\nMissing property: uaa.clients.#{id}.authorized-grant-types"
       else
-        message = message + "\nMissing property: uaa.clients.#{id}.secret" if client_data['secret'].nil? && client_data['authorized-grant-types'] != 'implicit' && client_data['token-endpoint-auth-method'] != 'tls_client_auth' && client_data['token-endpoint-auth-method'] != 'private_key_jwt'
+        message = message + "\nMissing property: uaa.clients.#{id}.secret" if
+            client_data['secret'].nil? &&
+            client_data['authorized-grant-types'] != 'implicit' &&
+            !has_mtls_ca
         if (client_data['redirect-uri'].nil? || client_data['redirect-uri'].empty?)
           message = message + "\nMissing property: uaa.clients.#{id}.redirect-uri" if client_data['authorized-grant-types'] =~ /implicit|authorization_code/
         elsif client_data['redirect-uri'].split(',').any? { |uri| !(uri =~ /^http(\*|s)?:\/\/(.*:.*@)?(([a-zA-Z0-9\-\*]+\.)*[a-zA-Z0-9\-]+\.)?[a-zA-Z0-9\-]+(:[0-9]+)?(\/.*|$)/) }
@@ -880,7 +887,3 @@
 
 %>
 <%= render(params) %>
-<% if p("uaa.mtls_enabled") %>
-mtls:
-  endpoint: <%= p("uaa.mtls_endpoint_path") %>
-<% end %>

--- a/jobs/uaa/templates/config/uaa.yml.erb
+++ b/jobs/uaa/templates/config/uaa.yml.erb
@@ -653,6 +653,7 @@
         'sleep' => p('uaa.shutdown.sleep')
       },
       'url' => uaa_base,
+      'mtls-enabled' => p('uaa.mtls_enabled'),
       'limitedFunctionality' => {
         'statusFile' => p('uaa.limitedFunctionality.statusFile'),
         'whitelist' => {

--- a/jobs/uaa/templates/config/uaa.yml.erb
+++ b/jobs/uaa/templates/config/uaa.yml.erb
@@ -371,6 +371,9 @@
       end
       has_mtls_ca = client_data['tls-client-auth-ca'].is_a?(String) &&
           !client_data['tls-client-auth-ca'].strip.empty?
+      client_data.delete('tls-client-auth-trusted-proxy-ca') if
+          client_data['tls-client-auth-trusted-proxy-ca'].is_a?(String) &&
+          client_data['tls-client-auth-trusted-proxy-ca'].strip.empty?
       message = message + "\nInvalid property: uaa.clients.#{id}.token-endpoint-auth-method" if
           client_data.key?('token-endpoint-auth-method')
       if !client['scopes'].nil?

--- a/jobs/uaa/templates/config/uaa.yml.erb
+++ b/jobs/uaa/templates/config/uaa.yml.erb
@@ -371,8 +371,8 @@
       end
       has_mtls_ca = client_data['tls-client-auth-ca'].is_a?(String) &&
           !client_data['tls-client-auth-ca'].strip.empty?
-      message = message + "\nInvalid property: uaa.clients.#{id}.token-endpoint-auth-method" unless
-          client_data['token-endpoint-auth-method'].nil?
+      message = message + "\nInvalid property: uaa.clients.#{id}.token-endpoint-auth-method" if
+          client_data.key?('token-endpoint-auth-method')
       if !client['scopes'].nil?
         client_data.delete('scopes')
         if client['scopes'].is_a? Array

--- a/spec/uaa-release.erb_spec.rb
+++ b/spec/uaa-release.erb_spec.rb
@@ -1289,6 +1289,12 @@ describe 'uaa-release erb generation' do
           expect { parsed_yaml }.not_to raise_error
         end
 
+        it 'omits a blank tls-client-auth-trusted-proxy-ca' do
+          generated_cf_manifest['properties']['uaa']['clients']['app']['tls-client-auth-trusted-proxy-ca'] = ' '
+
+          expect(parsed_yaml['oauth']['clients']['app']).not_to have_key('tls-client-auth-trusted-proxy-ca')
+        end
+
         it 'requires a secret when tls-client-auth-ca is absent' do
           expect {
             parsed_yaml

--- a/spec/uaa-release.erb_spec.rb
+++ b/spec/uaa-release.erb_spec.rb
@@ -1274,6 +1274,44 @@ describe 'uaa-release erb generation' do
         end
       end
 
+      context 'client_credentials mTLS clients' do
+        let(:erb_template) {'../jobs/uaa/templates/config/uaa.yml.erb'}
+
+        before do
+          client = generated_cf_manifest['properties']['uaa']['clients']['app']
+          client['authorized-grant-types'] = 'client_credentials'
+          client.delete('secret')
+        end
+
+        it 'allows a secretless client with a nonblank tls-client-auth-ca' do
+          generated_cf_manifest['properties']['uaa']['clients']['app']['tls-client-auth-ca'] = "-----BEGIN CERTIFICATE-----\nCA\n-----END CERTIFICATE-----"
+
+          expect { parsed_yaml }.not_to raise_error
+        end
+
+        it 'requires a secret when tls-client-auth-ca is absent' do
+          expect {
+            parsed_yaml
+          }.to raise_error(ArgumentError, /Missing property: uaa.clients.app.secret/)
+        end
+
+        it 'requires a secret when tls-client-auth-ca is blank' do
+          generated_cf_manifest['properties']['uaa']['clients']['app']['tls-client-auth-ca'] = ' '
+
+          expect {
+            parsed_yaml
+          }.to raise_error(ArgumentError, /Missing property: uaa.clients.app.secret/)
+        end
+
+        it 'does not exempt a client with private-key trust configuration from requiring a secret' do
+          generated_cf_manifest['properties']['uaa']['clients']['app']['client_jwt_config'] = '{}'
+
+          expect {
+            parsed_yaml
+          }.to raise_error(ArgumentError, /Missing property: uaa.clients.app.secret/)
+        end
+      end
+
       context 'redirect-uri is missing from required grant types' do
         let(:erb_template) {'../jobs/uaa/templates/config/uaa.yml.erb'}
         grant_types_requiring_secret = ['authorization_code', 'implicit']

--- a/spec/uaa-release.erb_spec.rb
+++ b/spec/uaa-release.erb_spec.rb
@@ -183,6 +183,19 @@ describe 'uaa-release erb generation' do
       end
     end
 
+    context 'when mTLS is enabled' do
+      let(:input) {'spec/input/test-defaults.yml'}
+      let(:erb_template) {'../jobs/uaa/templates/config/uaa.yml.erb'}
+
+      before do
+        generated_cf_manifest['properties']['uaa']['mtls_enabled'] = true
+      end
+
+      it 'does not render a configurable mtls endpoint block' do
+        expect(parsed_yaml).not_to have_key('mtls')
+      end
+    end
+
     context 'for deprecated-properties-still-work.yml' do
       let(:input) {'spec/input/deprecated-properties-still-work.yml'}
       let(:output_uaa) {'spec/compare/deprecated-properties-still-work-uaa.yml'}


### PR DESCRIPTION
## Summary

BOSH release changes to support [RFC 8705](https://www.rfc-editor.org/rfc/rfc8705)
mutual-TLS client authentication for Cloud Foundry app instance identity.

Companion to cloudfoundry/uaa#3972.

### Changes (3 commits)

**`jobs/uaa/spec`** — new properties:
- `uaa.mtls.enabled` (boolean, default `false`) — enables the `/oauth/mtls/token` endpoint
- `uaa.mtls.endpoint` (string) — the full mTLS endpoint URL published in OIDC discovery

**`jobs/uaa/templates/config/uaa.yml.erb`**:
- Emit `mtls:` block when `uaa.mtls.enabled` is true
- Skip `clientSecret` validation for `tls_client_auth` and `private_key_jwt` clients
  (these authenticate via cert/JWT rather than a shared secret)

**`src/uaa` submodule** — bumped to `feat/rfc8705-mtls-client-auth` (cloudfoundry/uaa#3972)

### Ops file usage

```yaml
# ops-enable-app-identity.yml
- type: replace
  path: /instance_groups/name=control/jobs/name=uaa/properties/uaa/mtls?
  value:
    enabled: true
    endpoint: https://uaa.((system_domain))/oauth/mtls/token

- type: replace
  path: /instance_groups/name=control/jobs/name=uaa/properties/uaa/clients/instance-identity?
  value:
    token-endpoint-auth-method: tls_client_auth
    tls-client-auth-ca: ((diego_instance_identity_ca.certificate))
    tls-client-auth-claim-mappings: |
      [
        {"field":"subject_cn","claim":"cf_instance_guid"},
        {"field":"subject_ou","pattern":"app:(.+)","claim":"app_guid"},
        {"field":"subject_ou","pattern":"space:(.+)","claim":"space_guid"},
        {"field":"subject_ou","pattern":"organization:(.+)","claim":"org_guid"}
      ]
    authorities: uaa.none
    authorized-grant-types: client_credentials
    scope: uaa.none
```

### Gorouter requirement

```yaml
# The Gorouter must be configured to validate and forward the client cert:
router.forwarded_client_cert: sanitize_set
```

### Related

- UAA Java implementation: cloudfoundry/uaa#3972
- RFC 8705: https://www.rfc-editor.org/rfc/rfc8705