### PR TITLE
Avoid OpenSSL PKCS12 generation for TLS keystore

### DIFF
--- a/jobs/uaa/templates/bin/pre-start.erb
+++ b/jobs/uaa/templates/bin/pre-start.erb
@@ -145,23 +145,26 @@ function process_certs {
 }
 
 function insert_ssl_cert {
-    local FIPS_OPTS=""
-    if [ -f "/proc/sys/crypto/fips_enabled" ]; then
-        local FIPS_ENABLED="$(cat /proc/sys/crypto/fips_enabled)"
-        if [ "${FIPS_ENABLED}" = 1 ]; then
-            FIPS_OPTS="-nomac"
-            log "Detect FIPS enabled"
-        fi
-    fi
+    local pkcs8_key="${TMP_DIR}/uaa-key.pk8.pem"
     log "Installing Server SSL certificate"
 
     rm -f /var/vcap/data/uaa/uaa_keystore.p12
 
-    openssl pkcs12 -export ${FIPS_OPTS} -name uaa_ssl_cert \
+    openssl pkcs8 -topk8 -nocrypt \
         -in /var/vcap/jobs/uaa/config/uaa.crt \
-        -out /var/vcap/data/uaa/uaa_keystore.p12 \
-        -password pass:k0*l*s3cur1tyr0ck$
+        -out "${pkcs8_key}"
 
+    /var/vcap/packages/uaa/jdk/bin/java \
+        -cp /var/vcap/packages/uaa/keystore-helper \
+        PemToKeyStore \
+        "${pkcs8_key}" \
+        /var/vcap/jobs/uaa/config/uaa.crt \
+        /var/vcap/data/uaa/uaa_keystore.p12 \
+        uaa_ssl_cert \
+        'k0*l*s3cur1tyr0ck$' \
+        PKCS12
+
+    rm -f "${pkcs8_key}"
     log "Installed Server SSL certificate"
 }
 

--- a/packages/uaa/packaging
+++ b/packages/uaa/packaging
@@ -14,6 +14,11 @@ fi
 # Ensure correct permissions
 chmod -R a+r jdk
 
+mkdir keystore-helper
+jdk/bin/javac --release 17 \
+  -d keystore-helper \
+  "${BOSH_COMPILE_TARGET}/keystore-helper/PemToKeyStore.java"
+
 tomcat_tar_file=$(find "${BOSH_COMPILE_TARGET}" -name "apache-tomcat-*.tar.gz" | sort --version-sort| tail -n1)
 mkdir tomcat
 tar zxvf "${tomcat_tar_file}" -C tomcat --strip 1

--- a/packages/uaa/spec
+++ b/packages/uaa/spec
@@ -5,3 +5,4 @@ files:
 - uaa/**/*
 - bellsoft-*.tar.gz
 - apache-*.tar.gz
+- keystore-helper/**/*

--- a/spec/uaa-release.erb_spec.rb
+++ b/spec/uaa-release.erb_spec.rb
@@ -56,6 +56,19 @@ describe 'uaa-release erb generation' do
     expect(actual).to eq(expected)
   end
 
+  context 'when rendering the pre-start script' do
+    let(:input) {'spec/input/test-defaults.yml'}
+    let(:manifest) {generate_cf_manifest(input)}
+    let(:template) {'../jobs/uaa/templates/bin/pre-start.erb'}
+    let(:script) {read_and_parse_string_template(template, manifest, false)}
+
+    it 'creates the server PKCS12 keystore without OpenSSL PKCS12' do
+      expect(script).to include('openssl pkcs8 -topk8 -nocrypt')
+      expect(script).to include('PemToKeyStore')
+      expect(script).not_to include('openssl pkcs12')
+    end
+  end
+
   context 'using bosh links' do
     let(:generated_cf_manifest) {generate_cf_manifest(input, links)}
     let(:input) {'spec/input/bosh-lite.yml'}

--- a/src/keystore-helper/PemToKeyStore.java
+++ b/src/keystore-helper/PemToKeyStore.java
@@ -1,0 +1,129 @@
+import java.io.ByteArrayInputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyFactory;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.Security;
+import java.security.Signature;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class PemToKeyStore {
+    private static final String[] KEY_ALGORITHMS = {"RSA", "EC", "DSA", "Ed25519", "Ed448"};
+
+    private PemToKeyStore() {}
+
+    private static List<byte[]> readPemBlocks(Path path, String label) throws Exception {
+        String pem = Files.readString(path, StandardCharsets.US_ASCII);
+        Pattern pattern = Pattern.compile(
+            "-----BEGIN " + Pattern.quote(label) + "-----\\s*(.*?)\\s*-----END "
+                + Pattern.quote(label) + "-----",
+            Pattern.DOTALL
+        );
+        Matcher matcher = pattern.matcher(pem);
+        List<byte[]> blocks = new ArrayList<>();
+        while (matcher.find()) {
+            blocks.add(Base64.getMimeDecoder().decode(matcher.group(1)));
+        }
+        if (blocks.isEmpty()) {
+            throw new IllegalArgumentException("Missing PEM block: " + label + " in " + path);
+        }
+        return blocks;
+    }
+
+    private static PrivateKey readPrivateKey(Path path) throws Exception {
+        PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(readPemBlocks(path, "PRIVATE KEY").get(0));
+        Exception last = null;
+        for (String algorithm : KEY_ALGORITHMS) {
+            try {
+                return KeyFactory.getInstance(algorithm).generatePrivate(spec);
+            } catch (Exception error) {
+                last = error;
+            }
+        }
+        throw new IllegalArgumentException("Unsupported PKCS#8 private key in " + path, last);
+    }
+
+    private static X509Certificate[] readCertificates(Path path) throws Exception {
+        CertificateFactory factory = CertificateFactory.getInstance("X.509");
+        List<byte[]> blocks = readPemBlocks(path, "CERTIFICATE");
+        X509Certificate[] certificates = new X509Certificate[blocks.size()];
+        for (int index = 0; index < blocks.size(); index++) {
+            certificates[index] = (X509Certificate) factory.generateCertificate(
+                new ByteArrayInputStream(blocks.get(index))
+            );
+        }
+        return certificates;
+    }
+
+    private static void verifyKeyPair(PrivateKey privateKey, X509Certificate certificate) throws Exception {
+        String algorithm = switch (privateKey.getAlgorithm()) {
+            case "RSA" -> "SHA256withRSA";
+            case "EC" -> "SHA256withECDSA";
+            case "DSA" -> "SHA256withDSA";
+            case "Ed25519" -> "Ed25519";
+            case "Ed448" -> "Ed448";
+            default -> throw new IllegalArgumentException(
+                "Unsupported key algorithm: " + privateKey.getAlgorithm()
+            );
+        };
+        byte[] message = "keystore-key-pair-check".getBytes(StandardCharsets.US_ASCII);
+        Signature signer = Signature.getInstance(algorithm);
+        signer.initSign(privateKey);
+        signer.update(message);
+        byte[] signature = signer.sign();
+        signer.initVerify(certificate.getPublicKey());
+        signer.update(message);
+        if (!signer.verify(signature)) {
+            throw new IllegalArgumentException("Private key does not match leaf certificate");
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 6) {
+            throw new IllegalArgumentException(
+                "Usage: PemToKeyStore PRIVATE_KEY CERTIFICATES OUTPUT ALIAS PASSWORD STORE_TYPE"
+            );
+        }
+
+        Path privateKeyPath = Path.of(args[0]);
+        Path certificatePath = Path.of(args[1]);
+        Path outputPath = Path.of(args[2]);
+        String alias = args[3];
+        char[] password = args[4].toCharArray();
+        String storeType = args[5].toUpperCase(Locale.ROOT);
+        if (!storeType.equals("JKS") && !storeType.equals("PKCS12")) {
+            throw new IllegalArgumentException("STORE_TYPE must be JKS or PKCS12");
+        }
+
+        if (storeType.equals("PKCS12")) {
+            Security.setProperty(
+                "keystore.pkcs12.keyProtectionAlgorithm",
+                "PBEWithHmacSHA256AndAES_256"
+            );
+            Security.setProperty("keystore.pkcs12.certProtectionAlgorithm", "NONE");
+            Security.setProperty("keystore.pkcs12.macAlgorithm", "NONE");
+        }
+
+        PrivateKey privateKey = readPrivateKey(privateKeyPath);
+        X509Certificate[] certificates = readCertificates(certificatePath);
+        verifyKeyPair(privateKey, certificates[0]);
+
+        KeyStore keyStore = KeyStore.getInstance(storeType);
+        keyStore.load(null, password);
+        keyStore.setKeyEntry(alias, privateKey, password, certificates);
+        try (OutputStream output = Files.newOutputStream(outputPath)) {
+            keyStore.store(output, password);
+        }
+    }
+}


### PR DESCRIPTION
OpenSSL 3 fails to export the TLS PKCS12 keystore on Noble FIPS because its generated PBKDF2 salt is shorter than the FIPS provider permits. The previous pre-start path could therefore prevent UAA from starting.

Normalize the PEM private key to PKCS#8, then use a packaged Java helper to create the PKCS12 keystore. Preserve the uaa_ssl_cert alias and certificate chain while avoiding OpenSSL's PKCS12 KDF path. Compile the helper during package creation and cover the rendered pre-start behavior in the template spec.